### PR TITLE
Replace mock content with real content and add quickstart page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -98,11 +98,11 @@
       "title": "Browser-native viewer",
       "description": "A lightweight viewer that reads STAC + cloud-native files directly."
     },
-    "validator": {
-      "name": "portolan-validator",
+    "skills": {
+      "name": "portolan-skills",
       "tag": "Stable",
-      "title": "Catalog validator",
-      "description": "CI-friendly checks for STAC, GeoParquet, COG conventions."
+      "title": "AI agent skills",
+      "description": "Ready-made skills that let Claude, Gemini, and Codex agents publish catalogs and query cloud-native geospatial data."
     },
     "readMore": "Read more"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,10 +4,11 @@
     "description": "Portolan is a toolkit and set of conventions for publishing geospatial data as cloud-native files on object storage. STAC + GeoParquet + COG, done right."
   },
   "nav": {
-    "tools": "Tools",
+    "why": "Why",
     "howItWorks": "How it works",
-    "catalogs": "Catalogs",
-    "docs": "Docs"
+    "tools": "Tools",
+    "docs": "Docs",
+    "quickstart": "Quickstart"
   },
   "hero": {
     "tagline": "A better spatial data infrastructure",
@@ -15,14 +16,7 @@
     "titleHighlight": "without the portal.",
     "description": "Portolan is a toolkit and set of conventions for publishing geospatial data as cloud-native files on object storage. STAC + GeoParquet + COG, done right, for governments and open data publishers.",
     "quickstart": "Quickstart",
-    "browseCatalogs": "Browse catalogs",
-    "stats": {
-      "activeNodes": "active nodes",
-      "collections": "collections",
-      "indexed": "indexed"
-    },
-    "mapCaption": "catalogs published from 9 jurisdictions",
-    "submitNode": "Submit a node"
+    "browseCatalogs": "Browse catalogs"
   },
   "why": {
     "eyebrow": "// WHY PORTOLAN",
@@ -60,6 +54,33 @@
       }
     }
   },
+  "howItWorks": {
+    "eyebrow": "// HOW IT WORKS",
+    "title": "Files on storage, not servers.",
+    "subtitle": "Portolan replaces traditional SDI servers with cloud-native files on object storage. No databases, no tile servers, no portal software — just files that browsers and AI agents read directly.",
+    "steps": {
+      "convert": {
+        "id": "01",
+        "title": "Convert",
+        "description": "Transform shapefiles, GeoTIFFs, and other formats into cloud-native equivalents — GeoParquet for vectors, COG for rasters, PMTiles for map tiles."
+      },
+      "catalog": {
+        "id": "02",
+        "title": "Catalog",
+        "description": "Generate a STAC catalog that describes every asset with structured metadata, rich descriptions, and links that AI agents and tools can follow."
+      },
+      "publish": {
+        "id": "03",
+        "title": "Publish",
+        "description": "Push files to any S3-compatible object storage — AWS, GCS, Azure, R2, MinIO, or Source Cooperative for free open data hosting."
+      },
+      "browse": {
+        "id": "04",
+        "title": "Browse",
+        "description": "Data is instantly accessible through any STAC-compatible viewer, queryable via DuckDB, and ready for AI agents — no servers to run."
+      }
+    }
+  },
   "toolkit": {
     "eyebrow": "// THE TOOLKIT",
     "title": "The toolkit.",
@@ -85,44 +106,6 @@
     },
     "readMore": "Read more"
   },
-  "catalogs": {
-    "eyebrow": "// LIVE NODES",
-    "title": "{count} catalogs running today.",
-    "featured": {
-      "title": "Coastal Bathymetry · Taiwan",
-      "tag": "Featured",
-      "description": "Nearshore bathymetric coverage in COG. Hosted on Source Cooperative.",
-      "size": "1.2 TB",
-      "collections": "4 collections",
-      "cost": "$0/mo"
-    },
-    "examples": {
-      "madrid": {
-        "name": "Madrid Open Data",
-        "description": "Vector base layers · GeoParquet",
-        "stats": "14 collections · 80 GB",
-        "cost": "$2.40/mo"
-      },
-      "andean": {
-        "name": "Andean Glacier Atlas",
-        "description": "Multi-temporal imagery + DEM",
-        "stats": "6 collections · 2.4 TB",
-        "cost": "$54/mo"
-      },
-      "pacific": {
-        "name": "Pacific NW Lidar",
-        "description": "COPC point clouds",
-        "stats": "9 collections · 11 TB",
-        "cost": "$0/mo"
-      },
-      "noaa": {
-        "name": "NOAA Marine Sanctuaries",
-        "description": "Habitat + species occurrence",
-        "stats": "22 collections · 340 GB",
-        "cost": "$8.20/mo"
-      }
-    }
-  },
   "footer": {
     "openGovernance": "Open governance",
     "license": "Apache-2.0",
@@ -138,6 +121,49 @@
       "nordic": "Nordic Hydro",
       "redSea": "Red Sea Reefs",
       "taiwan": "Coastal Bathymetry"
+    }
+  },
+  "quickstart": {
+    "title": "Quickstart",
+    "intro": "Get started with Portolan in minutes. Browse existing catalogs, then publish your own data.",
+    "browse": {
+      "eyebrow": "// STEP 1",
+      "title": "Browse a catalog",
+      "description": "Portolan catalogs are live on the web. Open the Portolan Browser to explore published datasets — view metadata, preview maps, and inspect data tables. Everything you see is served directly from cloud-native files on object storage, with zero servers.",
+      "cta": "Open the browser",
+      "duckdb": {
+        "title": "Query with DuckDB",
+        "description": "Any GeoParquet file in a Portolan catalog can be queried directly with DuckDB — no download needed. Just point at the URL."
+      }
+    },
+    "publish": {
+      "eyebrow": "// STEP 2",
+      "title": "Publish your data",
+      "description": "Two paths to get your data into a Portolan catalog."
+    },
+    "cli": {
+      "title": "With the CLI",
+      "description": "Install the portolan-cli, then init, add, convert, and push.",
+      "install": "Install",
+      "steps": {
+        "init": "Initialize a new catalog in your data directory",
+        "add": "Add your data files to the catalog",
+        "check": "Convert to cloud-native formats (GeoParquet, COG)",
+        "push": "Push to any S3-compatible storage"
+      }
+    },
+    "claude": {
+      "title": "With Claude",
+      "description": "If you have Claude Code, install the Portolan skill and point Claude at your data. It handles format conversion, metadata generation, and publishing.",
+      "steps": {
+        "install": "Install the Portolan CLI skill",
+        "run": "Then ask Claude to publish your data"
+      }
+    },
+    "next": {
+      "title": "What's next",
+      "docs": "Read the full CLI docs",
+      "github": "Browse the source on GitHub"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -98,11 +98,11 @@
       "title": "Browser-native viewer",
       "description": "A lightweight viewer that reads STAC + cloud-native files directly."
     },
-    "validator": {
-      "name": "portolan-validator",
+    "skills": {
+      "name": "portolan-skills",
       "tag": "Stable",
-      "title": "Catalog validator",
-      "description": "CI-friendly checks for STAC, GeoParquet, COG conventions."
+      "title": "AI agent skills",
+      "description": "Ready-made skills that let Claude, Gemini, and Codex agents publish catalogs and query cloud-native geospatial data."
     },
     "readMore": "Read more"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,10 +4,11 @@
     "description": "Portolan is a toolkit and set of conventions for publishing geospatial data as cloud-native files on object storage. STAC + GeoParquet + COG, done right."
   },
   "nav": {
-    "tools": "Tools",
+    "why": "Why",
     "howItWorks": "How it works",
-    "catalogs": "Catalogs",
-    "docs": "Docs"
+    "tools": "Tools",
+    "docs": "Docs",
+    "quickstart": "Quickstart"
   },
   "hero": {
     "tagline": "A better spatial data infrastructure",
@@ -15,14 +16,7 @@
     "titleHighlight": "without the portal.",
     "description": "Portolan is a toolkit and set of conventions for publishing geospatial data as cloud-native files on object storage. STAC + GeoParquet + COG, done right, for governments and open data publishers.",
     "quickstart": "Quickstart",
-    "browseCatalogs": "Browse catalogs",
-    "stats": {
-      "activeNodes": "active nodes",
-      "collections": "collections",
-      "indexed": "indexed"
-    },
-    "mapCaption": "catalogs published from 9 jurisdictions",
-    "submitNode": "Submit a node"
+    "browseCatalogs": "Browse catalogs"
   },
   "why": {
     "eyebrow": "// WHY PORTOLAN",
@@ -60,6 +54,33 @@
       }
     }
   },
+  "howItWorks": {
+    "eyebrow": "// HOW IT WORKS",
+    "title": "Files on storage, not servers.",
+    "subtitle": "Portolan replaces traditional SDI servers with cloud-native files on object storage. No databases, no tile servers, no portal software — just files that browsers and AI agents read directly.",
+    "steps": {
+      "convert": {
+        "id": "01",
+        "title": "Convert",
+        "description": "Transform shapefiles, GeoTIFFs, and other formats into cloud-native equivalents — GeoParquet for vectors, COG for rasters, PMTiles for map tiles."
+      },
+      "catalog": {
+        "id": "02",
+        "title": "Catalog",
+        "description": "Generate a STAC catalog that describes every asset with structured metadata, rich descriptions, and links that AI agents and tools can follow."
+      },
+      "publish": {
+        "id": "03",
+        "title": "Publish",
+        "description": "Push files to any S3-compatible object storage — AWS, GCS, Azure, R2, MinIO, or Source Cooperative for free open data hosting."
+      },
+      "browse": {
+        "id": "04",
+        "title": "Browse",
+        "description": "Data is instantly accessible through any STAC-compatible viewer, queryable via DuckDB, and ready for AI agents — no servers to run."
+      }
+    }
+  },
   "toolkit": {
     "eyebrow": "// THE TOOLKIT",
     "title": "The toolkit.",
@@ -85,44 +106,6 @@
     },
     "readMore": "Read more"
   },
-  "catalogs": {
-    "eyebrow": "// LIVE NODES",
-    "title": "{count} catalogs running today.",
-    "featured": {
-      "title": "Coastal Bathymetry · Taiwan",
-      "tag": "Featured",
-      "description": "Nearshore bathymetric coverage in COG. Hosted on Source Cooperative.",
-      "size": "1.2 TB",
-      "collections": "4 collections",
-      "cost": "$0/mo"
-    },
-    "examples": {
-      "madrid": {
-        "name": "Madrid Open Data",
-        "description": "Vector base layers · GeoParquet",
-        "stats": "14 collections · 80 GB",
-        "cost": "$2.40/mo"
-      },
-      "andean": {
-        "name": "Andean Glacier Atlas",
-        "description": "Multi-temporal imagery + DEM",
-        "stats": "6 collections · 2.4 TB",
-        "cost": "$54/mo"
-      },
-      "pacific": {
-        "name": "Pacific NW Lidar",
-        "description": "COPC point clouds",
-        "stats": "9 collections · 11 TB",
-        "cost": "$0/mo"
-      },
-      "noaa": {
-        "name": "NOAA Marine Sanctuaries",
-        "description": "Habitat + species occurrence",
-        "stats": "22 collections · 340 GB",
-        "cost": "$8.20/mo"
-      }
-    }
-  },
   "footer": {
     "openGovernance": "Open governance",
     "license": "Apache-2.0",
@@ -138,6 +121,49 @@
       "nordic": "Nordic Hydro",
       "redSea": "Red Sea Reefs",
       "taiwan": "Coastal Bathymetry"
+    }
+  },
+  "quickstart": {
+    "title": "Quickstart",
+    "intro": "Get started with Portolan in minutes. Browse existing catalogs, then publish your own data.",
+    "browse": {
+      "eyebrow": "// STEP 1",
+      "title": "Browse a catalog",
+      "description": "Portolan catalogs are live on the web. Open the Portolan Browser to explore published datasets — view metadata, preview maps, and inspect data tables. Everything you see is served directly from cloud-native files on object storage, with zero servers.",
+      "cta": "Open the browser",
+      "duckdb": {
+        "title": "Query with DuckDB",
+        "description": "Any GeoParquet file in a Portolan catalog can be queried directly with DuckDB — no download needed. Just point at the URL."
+      }
+    },
+    "publish": {
+      "eyebrow": "// STEP 2",
+      "title": "Publish your data",
+      "description": "Two paths to get your data into a Portolan catalog."
+    },
+    "cli": {
+      "title": "With the CLI",
+      "description": "Install the portolan-cli, then init, add, convert, and push.",
+      "install": "Install",
+      "steps": {
+        "init": "Initialize a new catalog in your data directory",
+        "add": "Add your data files to the catalog",
+        "check": "Convert to cloud-native formats (GeoParquet, COG)",
+        "push": "Push to any S3-compatible storage"
+      }
+    },
+    "claude": {
+      "title": "With Claude",
+      "description": "If you have Claude Code, install the Portolan skill and point Claude at your data. It handles format conversion, metadata generation, and publishing.",
+      "steps": {
+        "install": "Install the Portolan CLI skill",
+        "run": "Then ask Claude to publish your data"
+      }
+    },
+    "next": {
+      "title": "What's next",
+      "docs": "Read the full CLI docs",
+      "github": "Browse the source on GitHub"
     }
   }
 }

--- a/src/app/[locale]/quickstart/page.tsx
+++ b/src/app/[locale]/quickstart/page.tsx
@@ -1,0 +1,13 @@
+import { setRequestLocale } from "next-intl/server";
+import { QuickstartPage } from "@/components/quickstart-page";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function Quickstart({ params }: PageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <QuickstartPage />;
+}

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -4,8 +4,6 @@ import { useTranslations } from "next-intl";
 import { PortolanLogo } from "./portolan-logo";
 import { RhumbBackdrop } from "./rhumb-backdrop";
 import { DitherMap } from "./dither-map";
-import { MapPreview } from "./map-preview";
-import { LiveCount } from "./live-count";
 import { ThemeToggle } from "./theme-toggle";
 import { Btn, Tag, Card, Terminal } from "./ui";
 
@@ -40,27 +38,29 @@ export function HomePage() {
     { key: "breaks", id: "06" },
   ] as const;
 
-  const catalogExamples = [
-    { key: "madrid" },
-    { key: "andean" },
-    { key: "pacific" },
-    { key: "noaa" },
+  const howSteps = [
+    "convert",
+    "catalog",
+    "publish",
+    "browse",
   ] as const;
 
   return (
     <div className="bg-p-bg min-h-full font-sans">
       {/* Header */}
       <header className="flex items-center justify-between px-[var(--p-pad-xl)] py-5 border-b border-p-line-soft">
-        <PortolanLogo size={28} />
+        <a href="/">
+          <PortolanLogo size={28} />
+        </a>
         <nav className="flex gap-7 text-sm text-p-ink-2">
-          <a href="#tools" className="text-inherit hover:text-p-ink transition-colors">
-            {t("nav.tools")}
+          <a href="#why" className="text-inherit hover:text-p-ink transition-colors">
+            {t("nav.why")}
           </a>
           <a href="#how" className="text-inherit hover:text-p-ink transition-colors">
             {t("nav.howItWorks")}
           </a>
-          <a href="#examples" className="text-inherit hover:text-p-ink transition-colors">
-            {t("nav.catalogs")}
+          <a href="#tools" className="text-inherit hover:text-p-ink transition-colors">
+            {t("nav.tools")}
           </a>
           <a
             href="https://portolan-sdi.github.io/portolan-cli"
@@ -102,39 +102,25 @@ export function HomePage() {
               <p className="text-[17px] leading-relaxed mb-10">
                 {t("hero.description")}
               </p>
-              <div className="flex gap-4 mb-12 items-center flex-wrap">
-                <Btn variant="primary" size="lg">
-                  {t("hero.quickstart")} →
-                </Btn>
-                <a href="#examples">
+              <div className="flex gap-4 items-center flex-wrap">
+                <a href="/quickstart">
+                  <Btn variant="primary" size="lg">
+                    {t("hero.quickstart")} →
+                  </Btn>
+                </a>
+                <a href="https://browser.portolan-sdi.org/">
                   <Btn variant="secondary" size="lg">
                     {t("hero.browseCatalogs")}
                   </Btn>
                 </a>
               </div>
-              <div className="grid grid-cols-3 gap-8 pt-6 border-t border-dashed border-p-line max-w-[480px]">
-                {[
-                  { k: "47", d: t("hero.stats.activeNodes") },
-                  { k: "142", d: t("hero.stats.collections") },
-                  { k: "38 TB", d: t("hero.stats.indexed") },
-                ].map((s) => (
-                  <div key={s.k}>
-                    <div className="text-2xl font-semibold tracking-[-0.02em] mb-1">{s.k}</div>
-                    <div className="text-xs text-p-ink-3 font-mono">{s.d}</div>
-                  </div>
-                ))}
-              </div>
             </div>
           </div>
-        </div>
-        <div className="absolute bottom-4 right-6 z-10 font-mono text-xs text-p-ink-3 flex items-center gap-2">
-          <span className="w-1.5 h-1.5 rounded-full bg-p-accent shadow-[0_0_8px_var(--p-accent)]" />
-          {t("hero.mapCaption")}
         </div>
       </section>
 
       {/* Why Portolan */}
-      <section id="how" className="px-[var(--p-pad-xl)] py-[var(--p-pad-xl)]">
+      <section id="why" className="px-[var(--p-pad-xl)] py-[var(--p-pad-xl)]">
         <div className="max-w-[1240px] mx-auto">
           <div className="flex items-baseline justify-between mb-8">
             <div>
@@ -171,10 +157,43 @@ export function HomePage() {
         </div>
       </section>
 
+      {/* How it works */}
+      <section id="how" className="px-[var(--p-pad-xl)] py-[var(--p-pad-xl)] bg-p-bg-soft border-y border-p-line-soft">
+        <div className="max-w-[1240px] mx-auto">
+          <span className="font-mono text-[11px] text-p-ink-3 tracking-[0.08em]">
+            {t("howItWorks.eyebrow")}
+          </span>
+          <h2 className="text-4xl mt-1.5 mb-3 font-semibold tracking-[-0.02em]">
+            {t("howItWorks.title")}
+          </h2>
+          <p className="text-[15px] leading-relaxed max-w-[720px] mb-10">
+            {t("howItWorks.subtitle")}
+          </p>
+          <div className="grid grid-cols-4 gap-5">
+            {howSteps.map((step) => (
+              <Card key={step} className="!p-6 flex flex-col gap-3">
+                <div className="flex justify-between items-center">
+                  <span className="font-mono text-[11px] text-p-ink-3">
+                    {t(`howItWorks.steps.${step}.id`)}
+                  </span>
+                  <span className="w-2 h-2 rounded-full bg-p-accent" />
+                </div>
+                <h3 className="text-lg font-semibold">
+                  {t(`howItWorks.steps.${step}.title`)}
+                </h3>
+                <p className="text-[13.5px] leading-relaxed">
+                  {t(`howItWorks.steps.${step}.description`)}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* Toolkit */}
       <section
         id="tools"
-        className="px-[var(--p-pad-xl)] py-[calc(var(--p-pad-xl)*1.4)] bg-p-bg-soft relative overflow-hidden border-y border-p-line-soft"
+        className="px-[var(--p-pad-xl)] py-[calc(var(--p-pad-xl)*1.4)] relative overflow-hidden"
       >
         <RhumbBackdrop opacity={0.08} originX={15} originY={50} />
         <div className="max-w-[1240px] mx-auto relative">
@@ -187,113 +206,70 @@ export function HomePage() {
                 {t("toolkit.title")}
               </h2>
             </div>
-            <Btn variant="secondary" size="md">
-              {t("toolkit.allProjects")} →
-            </Btn>
+            <a href="https://github.com/portolan-sdi/">
+              <Btn variant="secondary" size="md">
+                {t("toolkit.allProjects")} →
+              </Btn>
+            </a>
           </div>
           <div className="grid grid-cols-[3fr_2fr] gap-5 items-stretch">
             {/* CLI Card */}
-            <Card className="!p-6 flex flex-col gap-4">
-              <div className="flex items-start justify-between">
-                <div>
-                  <div className="font-mono text-xs text-p-primary-ink mb-1">
-                    {t("toolkit.cli.name")}
+            <a href="https://cli.portolan-sdi.org/" className="contents">
+              <Card className="!p-6 flex flex-col gap-4 transition-shadow hover:shadow-[var(--p-shadow-md)]">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <div className="font-mono text-xs text-p-primary-ink mb-1">
+                      {t("toolkit.cli.name")}
+                    </div>
+                    <h3 className="text-[26px]">{t("toolkit.cli.title")}</h3>
                   </div>
-                  <h3 className="text-[26px]">{t("toolkit.cli.title")}</h3>
+                  <Tag tone="accent">{t("toolkit.cli.version")}</Tag>
                 </div>
-                <Tag tone="accent">{t("toolkit.cli.version")}</Tag>
-              </div>
-              <p className="text-sm leading-relaxed">{t("toolkit.cli.description")}</p>
-              <Terminal title="my-catalog · zsh" lines={terminalLines} />
-              <div className="font-mono text-[11.5px] text-p-ink-3 mt-auto">
-                {t("toolkit.cli.compatibility")}
-              </div>
-            </Card>
+                <p className="text-sm leading-relaxed">{t("toolkit.cli.description")}</p>
+                <Terminal title="my-catalog · zsh" lines={terminalLines} />
+                <div className="font-mono text-[11.5px] text-p-ink-3 mt-auto">
+                  {t("toolkit.cli.compatibility")}
+                </div>
+              </Card>
+            </a>
 
             {/* Side Cards */}
             <div className="grid grid-rows-2 gap-5 min-h-0">
-              <Card className="!p-5 flex flex-col gap-3">
-                <div className="flex justify-between items-start">
-                  <div className="font-mono text-xs text-p-primary-ink">
-                    {t("toolkit.viewer.name")}
+              <a href="https://github.com/portolan-sdi/portolan-browser" className="contents">
+                <Card className="!p-5 flex flex-col gap-3 transition-shadow hover:shadow-[var(--p-shadow-md)]">
+                  <div className="flex justify-between items-start">
+                    <div className="font-mono text-xs text-p-primary-ink">
+                      {t("toolkit.viewer.name")}
+                    </div>
+                    <Tag tone="default">{t("toolkit.viewer.tag")}</Tag>
                   </div>
-                  <Tag tone="default">{t("toolkit.viewer.tag")}</Tag>
-                </div>
-                <h3 className="text-xl">{t("toolkit.viewer.title")}</h3>
-                <p className="text-[13.5px] leading-relaxed">
-                  {t("toolkit.viewer.description")}
-                </p>
-                <a href="#" className="mt-auto text-[13px] hover:underline">
-                  {t("toolkit.readMore")} →
-                </a>
-              </Card>
-              <Card className="!p-5 flex flex-col gap-3">
-                <div className="flex justify-between items-start">
-                  <div className="font-mono text-xs text-p-primary-ink">
-                    {t("toolkit.validator.name")}
+                  <h3 className="text-xl">{t("toolkit.viewer.title")}</h3>
+                  <p className="text-[13.5px] leading-relaxed">
+                    {t("toolkit.viewer.description")}
+                  </p>
+                  <span className="mt-auto text-[13px] text-p-primary hover:underline">
+                    {t("toolkit.readMore")} →
+                  </span>
+                </Card>
+              </a>
+              <a href="https://github.com/portolan-sdi/portolan-validator" className="contents">
+                <Card className="!p-5 flex flex-col gap-3 transition-shadow hover:shadow-[var(--p-shadow-md)]">
+                  <div className="flex justify-between items-start">
+                    <div className="font-mono text-xs text-p-primary-ink">
+                      {t("toolkit.validator.name")}
+                    </div>
+                    <Tag tone="default">{t("toolkit.validator.tag")}</Tag>
                   </div>
-                  <Tag tone="default">{t("toolkit.validator.tag")}</Tag>
-                </div>
-                <h3 className="text-xl">{t("toolkit.validator.title")}</h3>
-                <p className="text-[13.5px] leading-relaxed">
-                  {t("toolkit.validator.description")}
-                </p>
-                <a href="#" className="mt-auto text-[13px] hover:underline">
-                  {t("toolkit.readMore")} →
-                </a>
-              </Card>
+                  <h3 className="text-xl">{t("toolkit.validator.title")}</h3>
+                  <p className="text-[13.5px] leading-relaxed">
+                    {t("toolkit.validator.description")}
+                  </p>
+                  <span className="mt-auto text-[13px] text-p-primary hover:underline">
+                    {t("toolkit.readMore")} →
+                  </span>
+                </Card>
+              </a>
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Catalogs */}
-      <section id="examples" className="px-[var(--p-pad-xl)] py-[var(--p-pad-xl)] bg-p-bg-soft">
-        <div className="max-w-[1240px] mx-auto">
-          <span className="font-mono text-[11px] text-p-ink-3 tracking-[0.08em]">
-            {t("catalogs.eyebrow")}
-          </span>
-          <h2 className="text-4xl mt-1.5 mb-10 font-semibold tracking-[-0.02em]">
-            <LiveCount target={142} /> {t("catalogs.title", { count: "" })}
-          </h2>
-          <div className="grid grid-cols-[1.5fr_1fr_1fr] gap-6">
-            {/* Featured Card */}
-            <Card className="!p-0 overflow-hidden">
-              <MapPreview height={320} className="!rounded-none !border-none !shadow-none" />
-              <div className="p-7">
-                <div className="flex justify-between items-center mb-5">
-                  <h3 className="text-lg">{t("catalogs.featured.title")}</h3>
-                  <Tag tone="accent">{t("catalogs.featured.tag")}</Tag>
-                </div>
-                <p className="text-sm leading-relaxed mb-6">{t("catalogs.featured.description")}</p>
-                <div className="font-mono text-xs text-p-ink-3 flex gap-6">
-                  <span>{t("catalogs.featured.size")}</span>
-                  <span>{t("catalogs.featured.collections")}</span>
-                  <span>{t("catalogs.featured.cost")}</span>
-                </div>
-              </div>
-            </Card>
-
-            {/* Example Cards */}
-            {catalogExamples.map((ex) => (
-              <Card key={ex.key} className="!p-7 flex flex-col gap-5">
-                <div className="flex items-center gap-3">
-                  <PortolanLogo size={28} withWordmark={false} />
-                  <h4 className="text-base font-medium">{t(`catalogs.examples.${ex.key}.name`)}</h4>
-                </div>
-                <p className="text-sm leading-relaxed">
-                  {t(`catalogs.examples.${ex.key}.description`)}
-                </p>
-                <div className="mt-auto pt-3 flex flex-col gap-2">
-                  <div className="font-mono text-xs text-p-ink-3">
-                    {t(`catalogs.examples.${ex.key}.stats`)}
-                  </div>
-                  <div className="font-mono text-xs text-p-success">
-                    ~{t(`catalogs.examples.${ex.key}.cost`)}
-                  </div>
-                </div>
-              </Card>
-            ))}
           </div>
         </div>
       </section>

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -252,17 +252,17 @@ export function HomePage() {
                   </span>
                 </Card>
               </a>
-              <a href="https://github.com/portolan-sdi/portolan-validator" className="contents">
+              <a href="https://github.com/portolan-sdi/portolan-skills" className="contents">
                 <Card className="!p-5 flex flex-col gap-3 transition-shadow hover:shadow-[var(--p-shadow-md)]">
                   <div className="flex justify-between items-start">
                     <div className="font-mono text-xs text-p-primary-ink">
-                      {t("toolkit.validator.name")}
+                      {t("toolkit.skills.name")}
                     </div>
-                    <Tag tone="default">{t("toolkit.validator.tag")}</Tag>
+                    <Tag tone="default">{t("toolkit.skills.tag")}</Tag>
                   </div>
-                  <h3 className="text-xl">{t("toolkit.validator.title")}</h3>
+                  <h3 className="text-xl">{t("toolkit.skills.title")}</h3>
                   <p className="text-[13.5px] leading-relaxed">
-                    {t("toolkit.validator.description")}
+                    {t("toolkit.skills.description")}
                   </p>
                   <span className="mt-auto text-[13px] text-p-primary hover:underline">
                     {t("toolkit.readMore")} →

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,5 +5,6 @@ export { DitherMap } from "./dither-map";
 export { MapPreview } from "./map-preview";
 export { LiveCount } from "./live-count";
 export { HomePage } from "./home-page";
+export { QuickstartPage } from "./quickstart-page";
 export { ThemeToggle } from "./theme-toggle";
 export * from "./ui";

--- a/src/components/quickstart-page.tsx
+++ b/src/components/quickstart-page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { PortolanLogo } from "./portolan-logo";
+import { ThemeToggle } from "./theme-toggle";
+import { Btn, Card, Terminal } from "./ui";
+
+const installLines = [
+  { text: "$ uv tool install portolan-cli", color: "#c5cce8" },
+];
+
+const cliLines = [
+  { text: "# Initialize a new catalog", color: "#5775d6" },
+  { text: "$ cd my-data && portolan init", color: "#c5cce8" },
+  { text: "", color: "#c5cce8" },
+  { text: "# Add your data files", color: "#5775d6" },
+  { text: "$ portolan add .", color: "#c5cce8" },
+  { text: "  ✓ found 12 files (parcels.shp, ortho.tif, roads.shp ...)", color: "#848bd8" },
+  { text: "", color: "#c5cce8" },
+  { text: "# Convert to cloud-native formats", color: "#5775d6" },
+  { text: "$ portolan check --fix", color: "#c5cce8" },
+  { text: "  → parcels.shp        →  GeoParquet", color: "#c5cce8" },
+  { text: "  → ortho.tif          →  COG", color: "#c5cce8" },
+  { text: "  → roads.shp          →  GeoParquet", color: "#c5cce8" },
+  { text: "  ✓ STAC catalog generated", color: "#848bd8" },
+  { text: "", color: "#c5cce8" },
+  { text: "# Push to cloud storage", color: "#5775d6" },
+  { text: "$ portolan push s3://my-bucket/catalog", color: "#c5cce8" },
+  { text: "  ✓ synced 12 assets to s3://my-bucket/catalog", color: "#848bd8" },
+  { text: "  ▸ https://my-bucket.s3.amazonaws.com/catalog.json", color: "#f4b860" },
+  { text: "", color: "#c5cce8" },
+  { text: "  done · 0:32 elapsed", color: "#28c840" },
+];
+
+const claudeInstallLines = [
+  { text: "# In Claude Code, install the Portolan skill", color: "#5775d6" },
+  { text: "$ claude install portolan-sdi/portolan-cli", color: "#c5cce8" },
+];
+
+const claudeRunLines = [
+  { text: "$ claude", color: "#c5cce8" },
+  { text: "", color: "#c5cce8" },
+  { text: "  > /portolan-cli publish the shapefiles in ./gov-data", color: "#f4b860" },
+  { text: "    to s3://my-catalog", color: "#f4b860" },
+];
+
+const duckdbLines = [
+  { text: "$ duckdb", color: "#c5cce8" },
+  { text: "", color: "#c5cce8" },
+  { text: "SELECT * FROM read_parquet(", color: "#c5cce8" },
+  { text: "  'https://my-catalog.s3.amazonaws.com/parcels.parquet'", color: "#f4b860" },
+  { text: ") WHERE area_sqm > 1000 LIMIT 10;", color: "#c5cce8" },
+];
+
+export function QuickstartPage() {
+  const t = useTranslations();
+
+  return (
+    <div className="bg-p-bg min-h-full font-sans">
+      {/* Header */}
+      <header className="flex items-center justify-between px-[var(--p-pad-xl)] py-5 border-b border-p-line-soft">
+        <a href="/">
+          <PortolanLogo size={28} />
+        </a>
+        <nav className="flex gap-7 text-sm text-p-ink-2">
+          <a href="/#why" className="text-inherit hover:text-p-ink transition-colors">
+            {t("nav.why")}
+          </a>
+          <a href="/#how" className="text-inherit hover:text-p-ink transition-colors">
+            {t("nav.howItWorks")}
+          </a>
+          <a href="/#tools" className="text-inherit hover:text-p-ink transition-colors">
+            {t("nav.tools")}
+          </a>
+          <a
+            href="https://portolan-sdi.github.io/portolan-cli"
+            className="text-inherit hover:text-p-ink transition-colors"
+          >
+            {t("nav.docs")} ↗
+          </a>
+        </nav>
+        <div className="flex gap-2">
+          <ThemeToggle />
+          <a
+            href="https://github.com/portolan-sdi"
+            aria-label="GitHub"
+            className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-p-ink-2 transition-colors hover:bg-p-bg-soft hover:text-p-ink"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.07 11.07 0 015.79 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.39-5.25 5.68.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z" />
+            </svg>
+          </a>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="px-[var(--p-pad-xl)] pt-[var(--p-pad-xl)] pb-[var(--p-pad-lg)]">
+        <div className="max-w-[860px] mx-auto">
+          <h1 className="text-[clamp(36px,4vw,52px)] leading-[1.1] font-semibold tracking-[-0.03em] mb-4">
+            {t("quickstart.title")}
+          </h1>
+          <p className="text-[17px] leading-relaxed text-p-ink-2">
+            {t("quickstart.intro")}
+          </p>
+        </div>
+      </section>
+
+      {/* Step 1: Browse */}
+      <section className="px-[var(--p-pad-xl)] py-[var(--p-pad-lg)]">
+        <div className="max-w-[860px] mx-auto">
+          <span className="font-mono text-[11px] text-p-ink-3 tracking-[0.08em]">
+            {t("quickstart.browse.eyebrow")}
+          </span>
+          <h2 className="text-3xl mt-1.5 mb-4 font-semibold tracking-[-0.02em]">
+            {t("quickstart.browse.title")}
+          </h2>
+          <p className="text-[15px] leading-relaxed mb-6">
+            {t("quickstart.browse.description")}
+          </p>
+          <a href="https://browser.portolan-sdi.org/" className="inline-block mb-10">
+            <Btn variant="primary" size="md">
+              {t("quickstart.browse.cta")} ↗
+            </Btn>
+          </a>
+
+          <Card className="!p-6">
+            <h3 className="text-lg font-semibold mb-2">
+              {t("quickstart.browse.duckdb.title")}
+            </h3>
+            <p className="text-[13.5px] leading-relaxed mb-4">
+              {t("quickstart.browse.duckdb.description")}
+            </p>
+            <Terminal title="duckdb" lines={duckdbLines} />
+          </Card>
+        </div>
+      </section>
+
+      {/* Step 2: Publish */}
+      <section className="px-[var(--p-pad-xl)] py-[var(--p-pad-lg)] bg-p-bg-soft border-y border-p-line-soft">
+        <div className="max-w-[860px] mx-auto">
+          <span className="font-mono text-[11px] text-p-ink-3 tracking-[0.08em]">
+            {t("quickstart.publish.eyebrow")}
+          </span>
+          <h2 className="text-3xl mt-1.5 mb-4 font-semibold tracking-[-0.02em]">
+            {t("quickstart.publish.title")}
+          </h2>
+          <p className="text-[15px] leading-relaxed mb-10">
+            {t("quickstart.publish.description")}
+          </p>
+
+          {/* CLI path */}
+          <div className="mb-12">
+            <h3 className="text-xl font-semibold mb-2">{t("quickstart.cli.title")}</h3>
+            <p className="text-[14px] leading-relaxed mb-4">
+              {t("quickstart.cli.description")}
+            </p>
+            <Terminal title="install · zsh" lines={installLines} />
+            <div className="mt-5">
+              <Terminal title="my-data · zsh" lines={cliLines} />
+            </div>
+          </div>
+
+          {/* Claude path */}
+          <div>
+            <h3 className="text-xl font-semibold mb-2">{t("quickstart.claude.title")}</h3>
+            <p className="text-[14px] leading-relaxed mb-4">
+              {t("quickstart.claude.description")}
+            </p>
+            <Terminal title="install skill · zsh" lines={claudeInstallLines} />
+            <div className="mt-5">
+              <Terminal title="claude code" lines={claudeRunLines} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What's next */}
+      <section className="px-[var(--p-pad-xl)] py-[var(--p-pad-lg)]">
+        <div className="max-w-[860px] mx-auto">
+          <h2 className="text-2xl mb-6 font-semibold tracking-[-0.02em]">
+            {t("quickstart.next.title")}
+          </h2>
+          <div className="flex gap-4 flex-wrap">
+            <a href="https://portolan-sdi.github.io/portolan-cli">
+              <Btn variant="secondary" size="md">
+                {t("quickstart.next.docs")} ↗
+              </Btn>
+            </a>
+            <a href="https://github.com/portolan-sdi">
+              <Btn variant="secondary" size="md">
+                {t("quickstart.next.github")} ↗
+              </Btn>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="px-[var(--p-pad-xl)] py-[var(--p-pad-lg)] border-t border-p-line-soft flex justify-between items-center text-[13px] text-p-ink-3 flex-wrap gap-4">
+        <PortolanLogo size={22} />
+        <div className="flex gap-6">
+          <span>{t("footer.openGovernance")}</span>
+          <span>{t("footer.license")}</span>
+          <span>{t("footer.repo")}</span>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Remove fake statistics (active nodes, collections, TB indexed) and the entire "Live Nodes" catalogs section with mock catalog entries
- Add a real "How it works" section explaining the convert → catalog → publish → browse workflow
- Reorder nav to Why / How it works / Tools to match section order
- Link "Browse catalogs" CTA to browser.portolan-sdi.org
- Add a new `/quickstart` page with CLI installation + usage and Claude Code publishing workflows
- Link toolkit cards to their project pages (CLI docs, portolan-browser GitHub, portolan-validator GitHub) and "All projects" to the GitHub org

## Test plan
- [ ] Verify homepage loads with no mock statistics or catalogs section
- [ ] Verify "How it works" section appears between Why and Toolkit
- [ ] Verify nav links (#why, #how, #tools) scroll to correct sections
- [ ] Verify "Browse catalogs" links to https://browser.portolan-sdi.org/
- [ ] Verify "Quickstart" links to /quickstart
- [ ] Verify /quickstart page renders with browse + CLI + Claude content
- [ ] Verify toolkit card links go to correct URLs
- [ ] Verify dark mode works on both pages
- [ ] Verify /es/ locale works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)