### PR TITLE
Add catalog registry with inline submit and bbox filtering

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -168,5 +168,53 @@
       "docs": "اقرأ توثيق واجهة سطر الأوامر كاملًا",
       "github": "تصفّح الكود على GitHub"
     }
+  },
+  "registry": {
+    "eyebrow": "// سجل الكتالوجات",
+    "title": "تصفّح {count} كتالوج",
+    "description": "اكتشف واتصل بكتالوجات STAC المتوافقة مع Portolan من جميع أنحاء العالم.",
+    "search": {
+      "placeholder": "ابحث في الكتالوجات...",
+      "noResults": "لا توجد كتالوجات تطابق بحثك",
+      "clearFilters": "مسح عوامل التصفية"
+    },
+    "filters": {
+      "tags": "الوسوم",
+      "access": "الوصول",
+      "validation": "التحقق",
+      "all": "الكل",
+      "bbox": "المنطقة",
+      "bboxLabel": "الإطار المحدد (WGS84)"
+    },
+    "access": {
+      "public": "عام",
+      "authenticated": "مصادق عليه"
+    },
+    "validation": {
+      "unvalidated": "غير موثق",
+      "basic": "أساسي",
+      "full": "كامل"
+    },
+    "card": {
+      "maintainer": "يديره",
+      "submitted": "أُرسل",
+      "viewCatalog": "عرض الكتالوج"
+    },
+    "cta": {
+      "title": "هل لديك كتالوج لمشاركته؟",
+      "description": "أرسل كتالوجك المتوافق مع Portolan إلى السجل.",
+      "button": "أرسل كتالوجك"
+    },
+    "submit": {
+      "title": "إرسال كتالوج",
+      "urlError": "يجب أن ينتهي الرابط بـ catalog.json",
+      "submit": "إرسال",
+      "submitting": "جارٍ الإرسال...",
+      "successTitle": "تم الإرسال!",
+      "successDescription": "سيظهر كتالوجك بعد المراجعة.",
+      "viewPr": "عرض الإرسال",
+      "submitAnother": "إرسال آخر"
+    },
+    "generated": "آخر تحديث: {date}"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -168,5 +168,53 @@
       "docs": "Read the full CLI docs",
       "github": "Browse the source on GitHub"
     }
+  },
+  "registry": {
+    "eyebrow": "// CATALOG REGISTRY",
+    "title": "Browse {count} catalogs",
+    "description": "Discover and connect to Portolan-compatible STAC catalogs from around the world.",
+    "search": {
+      "placeholder": "Search catalogs...",
+      "noResults": "No catalogs match your search",
+      "clearFilters": "Clear filters"
+    },
+    "filters": {
+      "tags": "Tags",
+      "access": "Access",
+      "validation": "Validation",
+      "all": "All",
+      "bbox": "Region",
+      "bboxLabel": "Bounding box (WGS84)"
+    },
+    "access": {
+      "public": "Public",
+      "authenticated": "Authenticated"
+    },
+    "validation": {
+      "unvalidated": "Unvalidated",
+      "basic": "Basic",
+      "full": "Full"
+    },
+    "card": {
+      "maintainer": "Maintained by",
+      "submitted": "Submitted",
+      "viewCatalog": "View catalog"
+    },
+    "cta": {
+      "title": "Have a catalog to share?",
+      "description": "Submit your Portolan-compatible catalog to the registry.",
+      "button": "Submit your catalog"
+    },
+    "submit": {
+      "title": "Submit a catalog",
+      "urlError": "URL must end with catalog.json",
+      "submit": "Submit",
+      "submitting": "Submitting...",
+      "successTitle": "Submitted!",
+      "successDescription": "Your catalog will appear after review.",
+      "viewPr": "View submission",
+      "submitAnother": "Submit another"
+    },
+    "generated": "Last updated: {date}"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -168,5 +168,53 @@
       "docs": "Lee la documentación completa de la CLI",
       "github": "Explora el código en GitHub"
     }
+  },
+  "registry": {
+    "eyebrow": "// REGISTRO DE CATÁLOGOS",
+    "title": "Explora {count} catálogos",
+    "description": "Descubre y conecta con catálogos STAC compatibles con Portolan de todo el mundo.",
+    "search": {
+      "placeholder": "Buscar catálogos...",
+      "noResults": "Ningún catálogo coincide con tu búsqueda",
+      "clearFilters": "Limpiar filtros"
+    },
+    "filters": {
+      "tags": "Etiquetas",
+      "access": "Acceso",
+      "validation": "Validación",
+      "all": "Todos",
+      "bbox": "Región",
+      "bboxLabel": "Caja delimitadora (WGS84)"
+    },
+    "access": {
+      "public": "Público",
+      "authenticated": "Autenticado"
+    },
+    "validation": {
+      "unvalidated": "Sin validar",
+      "basic": "Básico",
+      "full": "Completo"
+    },
+    "card": {
+      "maintainer": "Mantenido por",
+      "submitted": "Enviado",
+      "viewCatalog": "Ver catálogo"
+    },
+    "cta": {
+      "title": "¿Tienes un catálogo para compartir?",
+      "description": "Envía tu catálogo compatible con Portolan al registro.",
+      "button": "Enviar tu catálogo"
+    },
+    "submit": {
+      "title": "Enviar un catálogo",
+      "urlError": "La URL debe terminar en catalog.json",
+      "submit": "Enviar",
+      "submitting": "Enviando...",
+      "successTitle": "¡Enviado!",
+      "successDescription": "Tu catálogo aparecerá después de la revisión.",
+      "viewPr": "Ver envío",
+      "submitAnother": "Enviar otro"
+    },
+    "generated": "Última actualización: {date}"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "jose": "^6.2.3",
     "next": "16.2.5",
     "next-intl": "^4.11.0",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.5(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       next:
         specifier: 16.2.5
         version: 16.2.5(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1609,6 +1612,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3828,6 +3834,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import { setRequestLocale } from "next-intl/server";
 import { HomePage } from "@/components";
+import { getCatalogs } from "@/lib/catalogs";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -9,5 +10,13 @@ export default async function Home({ params }: PageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  return <HomePage />;
+  let catalogs: Awaited<ReturnType<typeof getCatalogs>>["catalogs"] = [];
+  try {
+    const data = await getCatalogs();
+    catalogs = data.catalogs;
+  } catch (err) {
+    console.error("Failed to fetch catalogs:", err);
+  }
+
+  return <HomePage catalogs={catalogs} />;
 }

--- a/src/app/api/submit-catalog/route.ts
+++ b/src/app/api/submit-catalog/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SignJWT, importPKCS8 } from "jose";
+
+const GITHUB_APP_ID = process.env.GITHUB_APP_ID;
+const GITHUB_INSTALLATION_ID = process.env.GITHUB_INSTALLATION_ID;
+const GITHUB_PRIVATE_KEY = process.env.GITHUB_PRIVATE_KEY;
+
+const REPO_OWNER = "portolan-sdi";
+const REPO_NAME = "portolan-registry";
+
+interface SubmitRequest {
+  url: string;
+}
+
+function deriveSlug(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+    const catalogIndex = pathParts.findIndex((p) => p === "catalog.json");
+    if (catalogIndex > 0) {
+      return pathParts[catalogIndex - 1];
+    }
+    if (pathParts.length >= 2) {
+      return pathParts[pathParts.length - 2];
+    }
+    return `catalog-${Date.now()}`;
+  } catch {
+    return `catalog-${Date.now()}`;
+  }
+}
+
+async function getInstallationToken(): Promise<string> {
+  if (!GITHUB_APP_ID || !GITHUB_INSTALLATION_ID || !GITHUB_PRIVATE_KEY) {
+    throw new Error("GitHub App credentials not configured");
+  }
+
+  const privateKey = await importPKCS8(GITHUB_PRIVATE_KEY, "RS256");
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = await new SignJWT({})
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt(now - 60)
+    .setExpirationTime(now + 600)
+    .setIssuer(GITHUB_APP_ID)
+    .sign(privateKey);
+
+  const res = await fetch(
+    `https://api.github.com/app/installations/${GITHUB_INSTALLATION_ID}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`Failed to get installation token: ${error}`);
+  }
+
+  const data = await res.json();
+  return data.token;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body: SubmitRequest = await req.json();
+    const { url } = body;
+
+    if (!url || !url.trim().endsWith("catalog.json")) {
+      return NextResponse.json(
+        { error: "URL must end with catalog.json" },
+        { status: 400 }
+      );
+    }
+
+    let token: string;
+    try {
+      token = await getInstallationToken();
+    } catch (err) {
+      console.error("Auth error:", err);
+      return NextResponse.json(
+        { error: "Server not configured for submissions" },
+        { status: 503 }
+      );
+    }
+
+    const slug = deriveSlug(url);
+    const branchName = `add-${slug}-${Date.now()}`;
+
+    const mainRef = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/git/ref/heads/main`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+      }
+    );
+
+    if (!mainRef.ok) {
+      throw new Error("Failed to get main branch ref");
+    }
+
+    const mainData = await mainRef.json();
+    const mainSha = mainData.object.sha;
+
+    const createBranch = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/git/refs`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({
+          ref: `refs/heads/${branchName}`,
+          sha: mainSha,
+        }),
+      }
+    );
+
+    if (!createBranch.ok) {
+      throw new Error("Failed to create branch");
+    }
+
+    const yamlContent = `url: ${url}\n`;
+    const filePath = `catalogs/${slug}.yaml`;
+
+    const createFile = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${filePath}`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({
+          message: `Add catalog: ${slug}`,
+          content: Buffer.from(yamlContent).toString("base64"),
+          branch: branchName,
+        }),
+      }
+    );
+
+    if (!createFile.ok) {
+      throw new Error("Failed to create file");
+    }
+
+    const createPr = await fetch(
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({
+          title: `Add catalog: ${slug}`,
+          head: branchName,
+          base: "main",
+          body: `Submitted via portolan.dev\n\nCatalog URL: ${url}`,
+        }),
+      }
+    );
+
+    if (!createPr.ok) {
+      const error = await createPr.text();
+      throw new Error(`Failed to create PR: ${error}`);
+    }
+
+    const prData = await createPr.json();
+
+    return NextResponse.json({
+      success: true,
+      pr_url: prData.html_url,
+      pr_number: prData.number,
+    });
+  } catch (err) {
+    console.error("Submit error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Submission failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { RhumbBackdrop } from "./rhumb-backdrop";
@@ -7,6 +8,15 @@ import { DitherMap } from "./dither-map";
 import { SiteHeader } from "./site-header";
 import { SiteFooter } from "./site-footer";
 import { Btn, Tag, Card, Terminal, DirArrow, Ltr } from "./ui";
+import { CatalogCard } from "./registry/catalog-card";
+import type { Catalog } from "@/lib/catalogs";
+import { getValidationTier } from "@/lib/catalogs";
+
+type SubmitState = "idle" | "submitting" | "success" | "error";
+
+interface HomePageProps {
+  catalogs?: Catalog[];
+}
 
 const terminalLines = [
   { text: "# Convert a folder of shapefiles + tiffs to a portable catalog", color: "#5775d6" },
@@ -27,8 +37,124 @@ const terminalLines = [
   { text: "  done · 0:48 elapsed", color: "#28c840" },
 ];
 
-export function HomePage() {
+export function HomePage({ catalogs = [] }: HomePageProps) {
   const t = useTranslations();
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  const [validationFilter, setValidationFilter] = useState<"all" | "unvalidated" | "basic" | "full">("all");
+  const [bboxFilter, setBboxFilter] = useState<{ west: string; south: string; east: string; north: string }>({
+    west: "", south: "", east: "", north: ""
+  });
+  const [showBboxFilter, setShowBboxFilter] = useState(false);
+
+  const [submitUrl, setSubmitUrl] = useState("");
+  const [submitState, setSubmitState] = useState<SubmitState>("idle");
+  const [submitPrUrl, setSubmitPrUrl] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const isValidSubmitUrl = submitUrl.trim().endsWith("catalog.json");
+
+  const allTags = useMemo(() => {
+    return Array.from(new Set(catalogs.flatMap((c) => c.keywords ?? []))).sort();
+  }, [catalogs]);
+
+  const parsedBbox = useMemo(() => {
+    const { west, south, east, north } = bboxFilter;
+    if (!west && !south && !east && !north) return null;
+    const w = parseFloat(west);
+    const s = parseFloat(south);
+    const e = parseFloat(east);
+    const n = parseFloat(north);
+    if ([w, s, e, n].some(isNaN)) return null;
+    return { west: w, south: s, east: e, north: n };
+  }, [bboxFilter]);
+
+  const filteredCatalogs = useMemo(() => {
+    return catalogs.filter((catalog) => {
+      const query = searchQuery.toLowerCase();
+      const matchesSearch =
+        query === "" ||
+        catalog.title.toLowerCase().includes(query) ||
+        catalog.description.toLowerCase().includes(query);
+
+      const catalogKeywords = catalog.keywords ?? [];
+      const matchesTags =
+        selectedTags.size === 0 ||
+        catalogKeywords.some((keyword) => selectedTags.has(keyword));
+
+      const tier = getValidationTier(catalog.validation);
+      const matchesValidation =
+        validationFilter === "all" || tier === validationFilter;
+
+      let matchesBbox = true;
+      if (parsedBbox && catalog.bbox) {
+        const [catWest, catSouth, catEast, catNorth] = catalog.bbox;
+        matchesBbox =
+          catEast >= parsedBbox.west &&
+          catWest <= parsedBbox.east &&
+          catNorth >= parsedBbox.south &&
+          catSouth <= parsedBbox.north;
+      }
+
+      return matchesSearch && matchesTags && matchesValidation && matchesBbox;
+    });
+  }, [catalogs, searchQuery, selectedTags, validationFilter, parsedBbox]);
+
+  const handleTagToggle = (tag: string) => {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) {
+        next.delete(tag);
+      } else {
+        next.add(tag);
+      }
+      return next;
+    });
+  };
+
+  const handleClearFilters = () => {
+    setSearchQuery("");
+    setSelectedTags(new Set());
+    setValidationFilter("all");
+    setBboxFilter({ west: "", south: "", east: "", north: "" });
+  };
+
+  const hasActiveFilters = searchQuery !== "" || selectedTags.size > 0 || validationFilter !== "all" || parsedBbox !== null;
+
+  const handleSubmitCatalog = async () => {
+    if (!isValidSubmitUrl || submitState === "submitting") return;
+
+    setSubmitState("submitting");
+    setSubmitError(null);
+
+    try {
+      const res = await fetch("/api/submit-catalog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: submitUrl.trim() }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || "Submission failed");
+      }
+
+      setSubmitPrUrl(data.pr_url);
+      setSubmitState("success");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Something went wrong");
+      setSubmitState("error");
+    }
+  };
+
+  const handleResetSubmit = () => {
+    setSubmitUrl("");
+    setSubmitState("idle");
+    setSubmitPrUrl(null);
+    setSubmitError(null);
+  };
 
   const whyCards = [
     { key: "open", id: "01" },
@@ -241,6 +367,214 @@ export function HomePage() {
           </div>
         </div>
       </section>
+
+      {/* Registry */}
+      {catalogs.length > 0 && (
+        <section id="registry" className="px-[var(--p-pad-section-x)] py-[var(--p-pad-section-y)] bg-p-bg-soft border-t border-p-line-soft">
+          <div className="max-w-[1240px] mx-auto">
+            <span className="font-mono text-eyebrow text-p-ink-3 tracking-[0.08em]">
+              {t("registry.eyebrow")}
+            </span>
+            <h2 className="text-section mt-1.5 mb-6 font-semibold tracking-[-0.02em]">
+              {t("registry.title", { count: catalogs.length })}
+            </h2>
+            <p className="text-body-lg text-p-ink-2 mb-8 max-w-2xl">
+              {t("registry.description")}
+            </p>
+
+            {/* Filters */}
+            <div className="space-y-4 mb-8">
+              <div className="flex flex-col sm:flex-row gap-4">
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder={t("registry.search.placeholder")}
+                  className="flex-1 bg-p-paper border border-p-line rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none focus:border-p-primary transition-colors"
+                />
+                <div className="relative">
+                  <select
+                    value={validationFilter}
+                    onChange={(e) => setValidationFilter(e.target.value as typeof validationFilter)}
+                    className="appearance-none bg-p-paper border border-p-line rounded-[var(--p-r-md)] pl-3 pr-8 py-2.5 text-body text-p-ink focus:outline-none focus:border-p-primary transition-colors cursor-pointer"
+                    aria-label={t("registry.filters.validation")}
+                  >
+                    <option value="all">{t("registry.filters.all")}</option>
+                    <option value="unvalidated">{t("registry.validation.unvalidated")}</option>
+                    <option value="basic">{t("registry.validation.basic")}</option>
+                    <option value="full">{t("registry.validation.full")}</option>
+                  </select>
+                  <svg className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-p-ink-3 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setShowBboxFilter(!showBboxFilter)}
+                  className={`flex items-center gap-2 px-3 py-2.5 text-body border rounded-[var(--p-r-md)] transition-colors ${
+                    showBboxFilter || parsedBbox
+                      ? "bg-[color-mix(in_oklab,var(--p-primary)_10%,transparent)] border-[color-mix(in_oklab,var(--p-primary)_25%,transparent)] text-p-primary-ink"
+                      : "bg-p-paper border-p-line text-p-ink hover:border-p-ink-3"
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                  </svg>
+                  {t("registry.filters.bbox")}
+                </button>
+              </div>
+
+              {showBboxFilter && (
+                <div className="flex flex-wrap items-center gap-3 p-4 bg-p-paper border border-p-line rounded-[var(--p-r-md)]">
+                  <span className="text-micro text-p-ink-3 font-mono w-full sm:w-auto">{t("registry.filters.bboxLabel")}</span>
+                  <div className="flex flex-wrap gap-2">
+                    {(["west", "south", "east", "north"] as const).map((dir) => (
+                      <div key={dir} className="flex items-center gap-1">
+                        <label className="text-micro text-p-ink-3 uppercase w-6">{dir[0]}</label>
+                        <input
+                          type="number"
+                          step="any"
+                          value={bboxFilter[dir]}
+                          onChange={(e) => setBboxFilter((prev) => ({ ...prev, [dir]: e.target.value }))}
+                          placeholder={dir === "west" || dir === "east" ? "lon" : "lat"}
+                          className="w-20 px-2 py-1.5 text-micro bg-p-bg border border-p-line rounded-[var(--p-r-sm)] text-p-ink placeholder:text-p-ink-3 focus:outline-none focus:border-p-primary"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {allTags.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {allTags.map((tag) => {
+                    const isSelected = selectedTags.has(tag);
+                    return (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => handleTagToggle(tag)}
+                        className={`text-micro font-mono px-3 py-1.5 rounded-full border transition-colors ${
+                          isSelected
+                            ? "bg-[color-mix(in_oklab,var(--p-primary)_12%,transparent)] text-p-primary-ink border-[color-mix(in_oklab,var(--p-primary)_25%,transparent)]"
+                            : "bg-p-bg text-p-ink-3 border-p-line hover:bg-p-line hover:text-p-ink-2"
+                        }`}
+                      >
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={handleClearFilters}
+                  className="text-micro text-p-ink-3 hover:text-p-ink-2 underline underline-offset-2"
+                >
+                  {t("registry.search.clearFilters")}
+                </button>
+              )}
+            </div>
+
+            {/* Catalog Grid */}
+            {filteredCatalogs.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                {filteredCatalogs.map((catalog) => (
+                  <CatalogCard
+                    key={catalog.id}
+                    catalog={catalog}
+                    onTagClick={handleTagToggle}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-body text-p-ink-2">{t("registry.search.noResults")}</p>
+                <button
+                  type="button"
+                  onClick={handleClearFilters}
+                  className="mt-3 text-small text-p-primary hover:underline"
+                >
+                  {t("registry.search.clearFilters")}
+                </button>
+              </div>
+            )}
+
+            {/* Inline Submit */}
+            <div className="mt-10 bg-p-paper border border-p-line rounded-[var(--p-r-lg)] p-6">
+              <div className="flex flex-col md:flex-row md:items-center gap-4">
+                <div className="flex-1">
+                  <h3 className="text-card-title font-semibold text-p-ink">{t("registry.cta.title")}</h3>
+                  <p className="text-body text-p-ink-2 mt-1">{t("registry.cta.description")}</p>
+                </div>
+                {submitState === "success" ? (
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2 text-body text-[var(--p-success)]">
+                      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      {t("registry.submit.successTitle")}
+                    </div>
+                    {submitPrUrl && (
+                      <a
+                        href={submitPrUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-small text-p-primary hover:underline"
+                      >
+                        {t("registry.submit.viewPr")} <DirArrow />
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      onClick={handleResetSubmit}
+                      className="text-micro text-p-ink-3 hover:text-p-ink-2 underline"
+                    >
+                      {t("registry.submit.submitAnother")}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex flex-col sm:flex-row gap-2 md:w-auto w-full">
+                    <div className="flex-1 sm:min-w-[300px]">
+                      <input
+                        type="url"
+                        value={submitUrl}
+                        onChange={(e) => setSubmitUrl(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && isValidSubmitUrl && handleSubmitCatalog()}
+                        placeholder="https://...catalog.json"
+                        disabled={submitState === "submitting"}
+                        className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
+                          submitUrl && !isValidSubmitUrl ? "border-red-400" : "border-p-line focus:border-p-primary"
+                        }`}
+                      />
+                      {submitUrl && !isValidSubmitUrl && (
+                        <p className="text-micro text-red-500 mt-1">{t("registry.submit.urlError")}</p>
+                      )}
+                      {submitError && (
+                        <p className="text-micro text-red-500 mt-1">{submitError}</p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleSubmitCatalog}
+                      disabled={!isValidSubmitUrl || submitState === "submitting"}
+                      className={`px-5 py-2.5 rounded-[var(--p-r-md)] text-body font-medium transition-all whitespace-nowrap ${
+                        isValidSubmitUrl && submitState !== "submitting"
+                          ? "bg-p-primary text-white hover:opacity-90"
+                          : "bg-p-line text-p-ink-3 cursor-not-allowed"
+                      }`}
+                    >
+                      {submitState === "submitting" ? t("registry.submit.submitting") : t("registry.submit.submit")}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Footer */}
       <SiteFooter />

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Card, Tag, DirArrow } from "../ui";
+import type { Catalog } from "@/lib/catalogs";
+import { getValidationTier } from "@/lib/catalogs";
+
+interface CatalogCardProps {
+  catalog: Catalog;
+  onTagClick?: (tag: string) => void;
+}
+
+function getRegionFromBbox(bbox: [number, number, number, number] | null): string | null {
+  if (!bbox) return null;
+  const [west, south, east, north] = bbox;
+  const centerLat = (south + north) / 2;
+  const centerLon = (west + east) / 2;
+
+  const latDir = centerLat >= 0 ? "N" : "S";
+  const lonDir = centerLon >= 0 ? "E" : "W";
+
+  return `${Math.abs(centerLat).toFixed(0)}${latDir}, ${Math.abs(centerLon).toFixed(0)}${lonDir}`;
+}
+
+export function CatalogCard({ catalog, onTagClick }: CatalogCardProps) {
+  const t = useTranslations("registry");
+  const tier = getValidationTier(catalog.validation);
+  const region = getRegionFromBbox(catalog.bbox);
+
+  return (
+    <Card className="flex flex-col gap-3">
+      <div className="flex justify-between items-start gap-2">
+        <h3 className="text-card-title font-semibold line-clamp-2">{catalog.title}</h3>
+        <Tag
+          tone={tier === "full" ? "accent" : tier === "basic" ? "primary" : "default"}
+          className="shrink-0"
+        >
+          {t(`validation.${tier}`)}
+        </Tag>
+      </div>
+
+      <p className="text-body text-p-ink-2 line-clamp-2">{catalog.description}</p>
+
+      <div className="flex flex-wrap gap-2 text-micro text-p-ink-3 font-mono">
+        <span>{catalog.collection_count} collections</span>
+        <span>·</span>
+        <span>STAC {catalog.stac_version}</span>
+        {region && (
+          <>
+            <span>·</span>
+            <span>{region}</span>
+          </>
+        )}
+      </div>
+
+      {catalog.keywords && catalog.keywords.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-1">
+          {catalog.keywords.slice(0, 3).map((keyword) => (
+            <button
+              key={keyword}
+              type="button"
+              onClick={() => onTagClick?.(keyword)}
+              className="text-micro font-mono px-2 py-1 rounded-full bg-p-bg-soft border border-p-line-soft text-p-ink-3 hover:text-p-ink-2 hover:bg-p-line transition-colors"
+            >
+              {keyword}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <a
+        href={catalog.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-auto text-small text-p-primary hover:underline"
+      >
+        {t("card.viewCatalog")} <DirArrow />
+      </a>
+    </Card>
+  );
+}

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -1,0 +1,55 @@
+export interface CatalogValidation {
+  stac_valid: boolean;
+  has_versions_json: boolean;
+  has_portolan_dir: boolean;
+  has_llms_txt?: boolean;
+}
+
+export interface Catalog {
+  id: string;
+  url: string;
+  title: string;
+  description: string;
+  stac_version: string;
+  providers: unknown;
+  keywords: string[] | null;
+  bbox: [number, number, number, number] | null;
+  license: string;
+  collection_count: number;
+  feature_count: number;
+  last_crawled: string;
+  validation: CatalogValidation;
+}
+
+export interface CatalogsResponse {
+  generated: string;
+  count: number;
+  catalogs: Catalog[];
+}
+
+const CATALOGS_URL =
+  "https://raw.githubusercontent.com/portolan-sdi/portolan-registry/main/exports/catalogs.json";
+
+export async function getCatalogs(): Promise<CatalogsResponse> {
+  const res = await fetch(CATALOGS_URL, {
+    next: { revalidate: 3600 },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch catalogs: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export function getValidationTier(validation: CatalogValidation): "unvalidated" | "basic" | "full" {
+  const { stac_valid, has_versions_json, has_portolan_dir } = validation;
+
+  if (stac_valid && has_versions_json && has_portolan_dir) {
+    return "full";
+  }
+  if (stac_valid) {
+    return "basic";
+  }
+  return "unvalidated";
+}


### PR DESCRIPTION
## Summary

- Adds catalog registry section fetching from portolan-registry exports
- Inline submit form replaces modal popup for simpler UX
- Bounding box (BBOX) geospatial filter for regional catalog discovery
- GitHub App authenticated API route for automated PR creation

## Test plan

- [ ] Visit /en#examples to see registry section
- [ ] Search by text, filter by validation tier
- [ ] Toggle "Region" button and enter bbox coords to filter geographically
- [ ] Submit a catalog URL (requires Vercel env vars in prod)
- [ ] Verify PR link appears on successful submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)