### PR TITLE
fix(registry): open catalogs in the browser, not raw JSON

### DIFF
--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Card, Tag, DirArrow } from "../ui";
 import type { Catalog } from "@/lib/catalogs";
-import { getValidationTier } from "@/lib/catalogs";
+import { getBrowserUrl, getValidationTier } from "@/lib/catalogs";
 
 interface CatalogCardProps {
   catalog: Catalog;
@@ -75,7 +75,7 @@ export function CatalogCard({ catalog, onTagClick }: CatalogCardProps) {
       )}
 
       <a
-        href={catalog.url}
+        href={getBrowserUrl(catalog.url)}
         target="_blank"
         rel="noopener noreferrer"
         className="mt-auto text-small text-p-primary hover:underline"

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -20,7 +20,7 @@ import type {
   ExpressionSpecification,
 } from "maplibre-gl";
 import type { Catalog } from "@/lib/catalogs";
-import { getValidationTier } from "@/lib/catalogs";
+import { getBrowserUrl, getValidationTier } from "@/lib/catalogs";
 import { MapGeocoder } from "./map-geocoder";
 import { Tag, DirArrow } from "../ui";
 import type { GeocodeSuggestion } from "@/hooks/use-geocode";
@@ -397,7 +397,7 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
               {selected.description}
             </p>
             <a
-              href={selected.url}
+              href={getBrowserUrl(selected.url)}
               target="_blank"
               rel="noopener noreferrer"
               className="mt-3 inline-block text-small text-p-primary hover:underline"

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -53,6 +53,18 @@ export async function getCatalogs(): Promise<CatalogsResponse> {
   return res.json();
 }
 
+// The Portolan browser opens any catalog.json via a hash route that carries the
+// host and path with the scheme stripped, e.g.
+//   https://data.source.coop/cholmes/portolan-nl/catalog.json
+//   -> https://browser.portolan-sdi.org/#/external/data.source.coop/cholmes/portolan-nl/catalog.json
+// Linking the raw JSON instead just dumps the document in the user's browser.
+const BROWSER_BASE = "https://browser.portolan-sdi.org/#/external/";
+
+export function getBrowserUrl(catalogUrl: string): string {
+  const withoutScheme = catalogUrl.replace(/^https?:\/\//, "");
+  return `${BROWSER_BASE}${withoutScheme}`;
+}
+
 export function getValidationTier(validation: CatalogValidation): "unvalidated" | "basic" | "full" {
   const { stac_valid, has_versions_json, has_portolan_dir } = validation;
 


### PR DESCRIPTION
## Problem

Clicking "View catalog" in the registry (both the catalog card and the map popup) linked straight at `catalog.url`, so it opened the raw `catalog.json` document, e.g. https://data.source.coop/cholmes/portolan-nl/catalog.json — a wall of JSON instead of a browsable catalog. Reported by Cayetano.

## Fix

Route the link through the Portolan browser's `#/external/` hash. The browser opens any catalog by carrying the host and path with the scheme stripped:

```
https://data.source.coop/cholmes/portolan-nl/catalog.json
-> https://browser.portolan-sdi.org/#/external/data.source.coop/cholmes/portolan-nl/catalog.json
```

- Add `getBrowserUrl()` to `src/lib/catalogs.ts`.
- Use it in `catalog-card.tsx` and `catalog-map.tsx`, the two places that link a catalog.

## Verification

`tsc --noEmit` and ESLint both clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)