### PR TITLE
fix: collect the address the registry needs to reach a submitter

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -164,6 +164,9 @@
     "submit": {
       "title": "إرسال كتالوج",
       "urlError": "يجب أن ينتهي الرابط بـ catalog.json",
+      "emailPlaceholder": "you@example.org",
+      "emailError": "أدخل عنوان بريد إلكتروني",
+      "emailHint": "نراسلك عليه إذا توقّف كتالوجك عن اجتياز التحقق",
       "submit": "إرسال",
       "submitting": "جارٍ الإرسال...",
       "successTitle": "تم الإرسال!",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -166,7 +166,7 @@
       "urlError": "يجب أن ينتهي الرابط بـ catalog.json",
       "emailPlaceholder": "you@example.org",
       "emailError": "أدخل عنوان بريد إلكتروني",
-      "emailHint": "نراسلك عليه إذا توقّف كتالوجك عن اجتياز التحقق",
+      "emailLabel": "نراسلك على هذا العنوان إذا توقّف كتالوجك عن اجتياز التحقق",
       "submit": "إرسال",
       "submitting": "جارٍ الإرسال...",
       "successTitle": "تم الإرسال!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -166,7 +166,7 @@
       "urlError": "URL must end with catalog.json",
       "emailPlaceholder": "you@example.org",
       "emailError": "Enter an email address",
-      "emailHint": "Where we write if your catalog stops validating",
+      "emailLabel": "We email you at this address if your catalog stops validating",
       "submit": "Submit",
       "submitting": "Submitting...",
       "successTitle": "Submitted!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -164,6 +164,9 @@
     "submit": {
       "title": "Submit a catalog",
       "urlError": "URL must end with catalog.json",
+      "emailPlaceholder": "you@example.org",
+      "emailError": "Enter an email address",
+      "emailHint": "Where we write if your catalog stops validating",
       "submit": "Submit",
       "submitting": "Submitting...",
       "successTitle": "Submitted!",

--- a/messages/es.json
+++ b/messages/es.json
@@ -164,6 +164,9 @@
     "submit": {
       "title": "Enviar un catálogo",
       "urlError": "La URL debe terminar en catalog.json",
+      "emailPlaceholder": "tu@ejemplo.org",
+      "emailError": "Introduce una dirección de correo",
+      "emailHint": "Aquí te escribimos si tu catálogo deja de validarse",
       "submit": "Enviar",
       "submitting": "Enviando...",
       "successTitle": "¡Enviado!",

--- a/messages/es.json
+++ b/messages/es.json
@@ -166,7 +166,7 @@
       "urlError": "La URL debe terminar en catalog.json",
       "emailPlaceholder": "tu@ejemplo.org",
       "emailError": "Introduce una dirección de correo",
-      "emailHint": "Aquí te escribimos si tu catálogo deja de validarse",
+      "emailLabel": "Te escribimos a esta dirección si tu catálogo deja de validarse",
       "submit": "Enviar",
       "submitting": "Enviando...",
       "successTitle": "¡Enviado!",

--- a/src/app/api/submit-catalog/route.ts
+++ b/src/app/api/submit-catalog/route.ts
@@ -11,7 +11,14 @@ const REPO_NAME = "portolan-registry";
 
 interface SubmitRequest {
   url: string;
+  submitterEmail: string;
 }
+
+// The registry requires an address on every entry, because a catalog goes
+// stale when its catalog.json cannot be fetched, and any address inside it is
+// then out of reach. Rejecting whitespace matters beyond shape: this value is
+// interpolated into YAML, and a newline in it would inject a second key.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function deriveSlug(url: string): string {
   try {
@@ -74,11 +81,21 @@ async function getInstallationToken(): Promise<string> {
 export async function POST(req: NextRequest) {
   try {
     const body: SubmitRequest = await req.json();
-    const { url } = body;
+    const url = body.url?.trim();
+    const submitterEmail = body.submitterEmail?.trim();
 
-    if (!url || !url.trim().endsWith("catalog.json")) {
+    if (!url || !url.endsWith("catalog.json")) {
       return NextResponse.json(
         { error: "URL must end with catalog.json" },
+        { status: 400 }
+      );
+    }
+
+    // Both guards sit ahead of getInstallationToken, so a malformed
+    // submission costs no GitHub call and leaves no half-made branch behind.
+    if (!submitterEmail || !EMAIL_PATTERN.test(submitterEmail)) {
+      return NextResponse.json(
+        { error: "Enter an email address the registry can reach you at" },
         { status: 400 }
       );
     }
@@ -133,7 +150,7 @@ export async function POST(req: NextRequest) {
       throw new Error("Failed to create branch");
     }
 
-    const yamlContent = `url: ${url}\n`;
+    const yamlContent = `url: ${url}\nsubmitter_email: ${submitterEmail}\n`;
     const filePath = `catalogs/${slug}.yaml`;
 
     const createFile = await fetch(

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -565,44 +565,40 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                     </button>
                   </div>
                 ) : (
-                  <div className="flex flex-col sm:flex-row gap-2 md:w-auto w-full">
-                    <div className="flex-1 sm:min-w-[300px] flex flex-col gap-2">
-                      <div>
-                        <input
-                          type="url"
-                          value={submitUrl}
-                          onChange={(e) => setSubmitUrl(e.target.value)}
-                          onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
-                          placeholder="https://...catalog.json"
-                          disabled={submitState === "submitting"}
-                          className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
-                            submitUrl && !isValidSubmitUrl ? "border-red-400" : "border-p-line focus:border-p-primary"
-                          }`}
-                        />
-                        {submitUrl && !isValidSubmitUrl && (
-                          <p className="text-micro text-red-500 mt-1">{t("registry.submit.urlError")}</p>
-                        )}
-                      </div>
-                      <div>
-                        <input
-                          type="email"
-                          value={submitEmail}
-                          onChange={(e) => setSubmitEmail(e.target.value)}
-                          onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
-                          placeholder={t("registry.submit.emailPlaceholder")}
-                          disabled={submitState === "submitting"}
-                          className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
-                            submitEmail && !isValidSubmitEmail ? "border-red-400" : "border-p-line focus:border-p-primary"
-                          }`}
-                        />
-                        {submitEmail && !isValidSubmitEmail ? (
-                          <p className="text-micro text-red-500 mt-1">{t("registry.submit.emailError")}</p>
-                        ) : (
-                          <p className="text-micro text-p-ink-3 mt-1">{t("registry.submit.emailHint")}</p>
-                        )}
-                      </div>
-                      {submitError && (
-                        <p className="text-micro text-red-500">{submitError}</p>
+                  <div className="md:w-auto w-full">
+                    <div className="flex flex-col sm:flex-row gap-2">
+                    <div className="flex-1 sm:min-w-[260px]">
+                      <input
+                        type="url"
+                        value={submitUrl}
+                        onChange={(e) => setSubmitUrl(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
+                        placeholder="https://...catalog.json"
+                        disabled={submitState === "submitting"}
+                        className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
+                          submitUrl && !isValidSubmitUrl ? "border-red-400" : "border-p-line focus:border-p-primary"
+                        }`}
+                      />
+                      {submitUrl && !isValidSubmitUrl && (
+                        <p className="text-micro text-red-500 mt-1">{t("registry.submit.urlError")}</p>
+                      )}
+                    </div>
+                    <div className="sm:w-[200px]">
+                      <input
+                        type="email"
+                        value={submitEmail}
+                        onChange={(e) => setSubmitEmail(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
+                        placeholder={t("registry.submit.emailPlaceholder")}
+                        aria-label={t("registry.submit.emailLabel")}
+                        title={t("registry.submit.emailLabel")}
+                        disabled={submitState === "submitting"}
+                        className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
+                          submitEmail && !isValidSubmitEmail ? "border-red-400" : "border-p-line focus:border-p-primary"
+                        }`}
+                      />
+                      {submitEmail && !isValidSubmitEmail && (
+                        <p className="text-micro text-red-500 mt-1">{t("registry.submit.emailError")}</p>
                       )}
                     </div>
                     <button
@@ -617,6 +613,10 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                     >
                       {submitState === "submitting" ? t("registry.submit.submitting") : t("registry.submit.submit")}
                     </button>
+                    </div>
+                    {submitError && (
+                      <p className="text-micro text-red-500 mt-1">{submitError}</p>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -60,11 +60,16 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const [registryView, setRegistryView] = useState<"cards" | "map">("map");
 
   const [submitUrl, setSubmitUrl] = useState("");
+  const [submitEmail, setSubmitEmail] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
   const [submitPrUrl, setSubmitPrUrl] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const isValidSubmitUrl = submitUrl.trim().endsWith("catalog.json");
+  // Same shape the API enforces. The registry writes to this address when a
+  // catalog stops validating, so an entry without one is rejected at its gate.
+  const isValidSubmitEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(submitEmail.trim());
+  const canSubmit = isValidSubmitUrl && isValidSubmitEmail;
 
   // Live registry totals shown in the hero stats row. Latin digits in every
   // locale per the translation contract.
@@ -155,7 +160,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const hasActiveFilters = searchQuery !== "" || selectedTags.size > 0 || validationFilter !== "all" || parsedBbox !== null;
 
   const handleSubmitCatalog = async () => {
-    if (!isValidSubmitUrl || submitState === "submitting") return;
+    if (!canSubmit || submitState === "submitting") return;
 
     setSubmitState("submitting");
     setSubmitError(null);
@@ -164,7 +169,10 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
       const res = await fetch("/api/submit-catalog", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: submitUrl.trim() }),
+        body: JSON.stringify({
+          url: submitUrl.trim(),
+          submitterEmail: submitEmail.trim(),
+        }),
       });
 
       const data = await res.json();
@@ -183,6 +191,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
 
   const handleResetSubmit = () => {
     setSubmitUrl("");
+    setSubmitEmail("");
     setSubmitState("idle");
     setSubmitPrUrl(null);
     setSubmitError(null);
@@ -557,31 +566,51 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                   </div>
                 ) : (
                   <div className="flex flex-col sm:flex-row gap-2 md:w-auto w-full">
-                    <div className="flex-1 sm:min-w-[300px]">
-                      <input
-                        type="url"
-                        value={submitUrl}
-                        onChange={(e) => setSubmitUrl(e.target.value)}
-                        onKeyDown={(e) => e.key === "Enter" && isValidSubmitUrl && handleSubmitCatalog()}
-                        placeholder="https://...catalog.json"
-                        disabled={submitState === "submitting"}
-                        className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
-                          submitUrl && !isValidSubmitUrl ? "border-red-400" : "border-p-line focus:border-p-primary"
-                        }`}
-                      />
-                      {submitUrl && !isValidSubmitUrl && (
-                        <p className="text-micro text-red-500 mt-1">{t("registry.submit.urlError")}</p>
-                      )}
+                    <div className="flex-1 sm:min-w-[300px] flex flex-col gap-2">
+                      <div>
+                        <input
+                          type="url"
+                          value={submitUrl}
+                          onChange={(e) => setSubmitUrl(e.target.value)}
+                          onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
+                          placeholder="https://...catalog.json"
+                          disabled={submitState === "submitting"}
+                          className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
+                            submitUrl && !isValidSubmitUrl ? "border-red-400" : "border-p-line focus:border-p-primary"
+                          }`}
+                        />
+                        {submitUrl && !isValidSubmitUrl && (
+                          <p className="text-micro text-red-500 mt-1">{t("registry.submit.urlError")}</p>
+                        )}
+                      </div>
+                      <div>
+                        <input
+                          type="email"
+                          value={submitEmail}
+                          onChange={(e) => setSubmitEmail(e.target.value)}
+                          onKeyDown={(e) => e.key === "Enter" && canSubmit && handleSubmitCatalog()}
+                          placeholder={t("registry.submit.emailPlaceholder")}
+                          disabled={submitState === "submitting"}
+                          className={`w-full bg-p-bg border rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none transition-colors disabled:opacity-50 ${
+                            submitEmail && !isValidSubmitEmail ? "border-red-400" : "border-p-line focus:border-p-primary"
+                          }`}
+                        />
+                        {submitEmail && !isValidSubmitEmail ? (
+                          <p className="text-micro text-red-500 mt-1">{t("registry.submit.emailError")}</p>
+                        ) : (
+                          <p className="text-micro text-p-ink-3 mt-1">{t("registry.submit.emailHint")}</p>
+                        )}
+                      </div>
                       {submitError && (
-                        <p className="text-micro text-red-500 mt-1">{submitError}</p>
+                        <p className="text-micro text-red-500">{submitError}</p>
                       )}
                     </div>
                     <button
                       type="button"
                       onClick={handleSubmitCatalog}
-                      disabled={!isValidSubmitUrl || submitState === "submitting"}
-                      className={`px-5 py-2.5 rounded-[var(--p-r-md)] text-body font-semibold transition-colors whitespace-nowrap ${
-                        isValidSubmitUrl && submitState !== "submitting"
+                      disabled={!canSubmit || submitState === "submitting"}
+                      className={`px-5 py-2.5 rounded-[var(--p-r-md)] text-body font-semibold transition-colors whitespace-nowrap sm:self-start ${
+                        canSubmit && submitState !== "submitting"
                           ? "bg-p-primary text-p-on-primary hover:bg-p-primary-ink"
                           : "bg-p-line text-p-ink-3 cursor-not-allowed"
                       }`}


### PR DESCRIPTION
## What this changes

- The form asks for an email address. It sends the address to the API.
- The API requires the address and checks its shape.
- The API writes `submitter_email` into the entry file.
- Both checks run before the GitHub call. A bad request makes no API call.
- Three message files get new text: English, Spanish, and Arabic.

## Why

Resolves https://github.com/portolan-sdi/portolan-registry/issues/49. A catalog becomes stale when the registry cannot read its `catalog.json`. An address inside that file is then out of reach. The registry keeps the address in its own entry file instead. This form sent only the URL. Each web submission failed two checks: the schema job and the entry gate.

## Verification

Data read: https://data.source.coop/cholmes/trimet/catalog.json

The registry gate accepts the new entry. It rejects the old entry.

```console
$ uv run --frozen scripts/validate_entries.py \
    --changed-file changed.txt --catalog-dir websub
=== Processing trimet-websubmit.yaml ===
  Submitter: nlebovits@pm.me
Crawling: https://data.source.coop/cholmes/trimet/catalog.json
  Title: TriMet Geospatial Data
  Collections: 8
=== All changed catalogs validated successfully ===

$ uv run --frozen scripts/validate_entries.py \
    --changed-file changed_old.txt --catalog-dir websub_old
=== ERRORS ===
  - trimet-websubmit.yaml: Missing submitter_email for catalog trimet-websubmit
```

The schema job gives the same result on the two entries.

```console
new (with address): VALID
old (url only): INVALID -> 'submitter_email' is a required property
```

The API refuses three bad requests. It makes no GitHub call. The third request holds a newline, which could add a second YAML key.

```console
$ curl -s -X POST localhost:3000/api/submit-catalog \
    -H 'Content-Type: application/json' \
    -d '{"url":"https://data.source.coop/cholmes/trimet/catalog.json"}'
{"error":"Enter an email address the registry can reach you at"}
HTTP 400

$ ... -d '{"url":"...catalog.json","submitterEmail":"not-an-email"}'
HTTP 400

$ ... -d '{"url":"...catalog.json","submitterEmail":"a@b.org\nstatus: valid"}'
HTTP 400
```

The API accepts a good request. It then stops at the login step, because a local run has no keys.

```console
$ ... -d '{"url":"...catalog.json","submitterEmail":"nlebovits@pm.me"}'
{"error":"Server not configured for submissions"}
HTTP 503
```

```console
$ pnpm lint
✓ ESLint: No issues found

$ pnpm build
✓ Generating static pages using 10 workers (13/13) in 765ms
ƒ /api/submit-catalog
```
