### PR TITLE
feat: render catalog logos and read the live registry export

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -154,7 +154,8 @@
       "maintainer": "يديره",
       "submitted": "أُرسل",
       "viewCatalog": "عرض الكتالوج",
-      "collections": "{count, plural, other {# مجموعة}}"
+      "collections": "{count, plural, other {# مجموعة}}",
+      "licenses": "{count, plural, other {# رخصة}}"
     },
     "cta": {
       "title": "هل لديك كتالوج لمشاركته؟",

--- a/messages/en.json
+++ b/messages/en.json
@@ -154,7 +154,8 @@
       "maintainer": "Maintained by",
       "submitted": "Submitted",
       "viewCatalog": "View catalog",
-      "collections": "{count, plural, one {# collection} other {# collections}}"
+      "collections": "{count, plural, one {# collection} other {# collections}}",
+      "licenses": "{count, plural, one {# license} other {# licenses}}"
     },
     "cta": {
       "title": "Have a catalog to share?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -154,7 +154,8 @@
       "maintainer": "Mantenido por",
       "submitted": "Enviado",
       "viewCatalog": "Ver catálogo",
-      "collections": "{count, plural, one {# colección} other {# colecciones}}"
+      "collections": "{count, plural, one {# colección} other {# colecciones}}",
+      "licenses": "{count, plural, one {# licencia} other {# licencias}}"
     },
     "cta": {
       "title": "¿Tienes un catálogo para compartir?",

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -51,7 +51,6 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const locale = useLocale();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
   const [validationFilter, setValidationFilter] = useState<"all" | "unvalidated" | "basic" | "full">("all");
   const [bboxFilter, setBboxFilter] = useState<{ west: string; south: string; east: string; north: string }>({
     west: "", south: "", east: "", north: ""
@@ -87,10 +86,6 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
     ];
   }, [catalogs, locale]);
 
-  const allTags = useMemo(() => {
-    return Array.from(new Set(catalogs.flatMap((c) => c.keywords ?? []))).sort();
-  }, [catalogs]);
-
   const parsedBbox = useMemo(() => {
     const { west, south, east, north } = bboxFilter;
     if (!west && !south && !east && !north) return null;
@@ -105,15 +100,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const filteredCatalogs = useMemo(() => {
     return catalogs.filter((catalog) => {
       const query = searchQuery.toLowerCase();
-      const matchesSearch =
-        query === "" ||
-        catalog.title.toLowerCase().includes(query) ||
-        catalog.description.toLowerCase().includes(query);
-
-      const catalogKeywords = catalog.keywords ?? [];
-      const matchesTags =
-        selectedTags.size === 0 ||
-        catalogKeywords.some((keyword) => selectedTags.has(keyword));
+      const matchesSearch = query === "" || catalog.title.toLowerCase().includes(query);
 
       const tier = getValidationTier(catalog.validation);
       const matchesValidation =
@@ -129,30 +116,17 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
           catSouth <= parsedBbox.north;
       }
 
-      return matchesSearch && matchesTags && matchesValidation && matchesBbox;
+      return matchesSearch && matchesValidation && matchesBbox;
     });
-  }, [catalogs, searchQuery, selectedTags, validationFilter, parsedBbox]);
-
-  const handleTagToggle = (tag: string) => {
-    setSelectedTags((prev) => {
-      const next = new Set(prev);
-      if (next.has(tag)) {
-        next.delete(tag);
-      } else {
-        next.add(tag);
-      }
-      return next;
-    });
-  };
+  }, [catalogs, searchQuery, validationFilter, parsedBbox]);
 
   const handleClearFilters = () => {
     setSearchQuery("");
-    setSelectedTags(new Set());
     setValidationFilter("all");
     setBboxFilter({ west: "", south: "", east: "", north: "" });
   };
 
-  const hasActiveFilters = searchQuery !== "" || selectedTags.size > 0 || validationFilter !== "all" || parsedBbox !== null;
+  const hasActiveFilters = searchQuery !== "" || validationFilter !== "all" || parsedBbox !== null;
 
   const handleSubmitCatalog = async () => {
     if (!isValidSubmitUrl || submitState === "submitting") return;
@@ -455,28 +429,6 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                 </div>
               )}
 
-              {allTags.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {allTags.map((tag) => {
-                    const isSelected = selectedTags.has(tag);
-                    return (
-                      <button
-                        key={tag}
-                        type="button"
-                        onClick={() => handleTagToggle(tag)}
-                        className={`text-micro font-mono px-3 py-1.5 rounded-[var(--p-r-sm)] border transition-colors ${
-                          isSelected
-                            ? "bg-[color-mix(in_oklab,var(--p-primary)_12%,transparent)] text-p-primary-ink border-[color-mix(in_oklab,var(--p-primary)_25%,transparent)]"
-                            : "bg-p-bg text-p-ink-3 border-p-line hover:bg-p-line hover:text-p-ink-2"
-                        }`}
-                      >
-                        {tag}
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-
               {hasActiveFilters && (
                 <button
                   type="button"
@@ -494,11 +446,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
             ) : filteredCatalogs.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
                 {filteredCatalogs.map((catalog) => (
-                  <CatalogCard
-                    key={catalog.id}
-                    catalog={catalog}
-                    onTagClick={handleTagToggle}
-                  />
+                  <CatalogCard key={catalog.id} catalog={catalog} />
                 ))}
               </div>
             ) : (

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Card, Tag, DirArrow } from "../ui";
+import { Card, Tag, DirArrow, Ltr } from "../ui";
 import type { Catalog } from "@/lib/catalogs";
-import { getBrowserUrl, getValidationTier } from "@/lib/catalogs";
+import { getBrowserUrl, getLicenseSummary, getValidationTier } from "@/lib/catalogs";
 
 interface CatalogCardProps {
   catalog: Catalog;
-  onTagClick?: (tag: string) => void;
 }
 
 function getRegionFromBbox(bbox: [number, number, number, number] | null) {
@@ -24,13 +24,31 @@ function getRegionFromBbox(bbox: [number, number, number, number] | null) {
   };
 }
 
-export function CatalogCard({ catalog, onTagClick }: CatalogCardProps) {
+export function CatalogCard({ catalog }: CatalogCardProps) {
   const t = useTranslations("registry");
+  const [logoBroken, setLogoBroken] = useState(false);
   const tier = getValidationTier(catalog.validation);
   const region = getRegionFromBbox(catalog.bbox);
+  const license = getLicenseSummary(catalog.licenses);
+  const logo = logoBroken ? null : catalog.logo;
 
   return (
     <Card className="flex flex-col gap-3">
+      {logo && (
+        // Logos come from whatever host the catalog lives on, so there is no
+        // finite allowlist to give next/image's remotePatterns. A plain <img>
+        // keeps the optimizer from becoming an open proxy. The registry checks
+        // the image resolves at crawl time; onError covers later rot.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={logo.href}
+          alt={logo.title ?? catalog.title}
+          onError={() => setLogoBroken(true)}
+          loading="lazy"
+          className="h-8 w-auto max-w-[160px] self-start object-contain"
+        />
+      )}
+
       <div className="flex justify-between items-start gap-2">
         <h3 className="text-card-title font-semibold line-clamp-2">{catalog.title}</h3>
         <Tag
@@ -41,12 +59,26 @@ export function CatalogCard({ catalog, onTagClick }: CatalogCardProps) {
         </Tag>
       </div>
 
-      <p className="text-body text-p-ink-2 line-clamp-2">{catalog.description}</p>
-
       <div className="flex flex-wrap gap-2 text-micro text-p-ink-3 font-mono">
         <span>{t("card.collections", { count: catalog.collection_count })}</span>
-        <span>·</span>
-        <span>STAC {catalog.stac_version}</span>
+        {catalog.stac_version && (
+          <>
+            <span>·</span>
+            <span>STAC {catalog.stac_version}</span>
+          </>
+        )}
+        {license && (
+          <>
+            <span>·</span>
+            <span>
+              {license.kind === "single" ? (
+                <Ltr>{license.id}</Ltr>
+              ) : (
+                t("card.licenses", { count: license.count })
+              )}
+            </span>
+          </>
+        )}
         {region && (
           <>
             <span>·</span>
@@ -58,21 +90,6 @@ export function CatalogCard({ catalog, onTagClick }: CatalogCardProps) {
           </>
         )}
       </div>
-
-      {catalog.keywords && catalog.keywords.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-1">
-          {catalog.keywords.slice(0, 3).map((keyword) => (
-            <button
-              key={keyword}
-              type="button"
-              onClick={() => onTagClick?.(keyword)}
-              className="text-micro font-mono px-2 py-1 rounded-[var(--p-r-sm)] bg-p-bg-soft border border-p-line-soft text-p-ink-3 hover:text-p-ink-2 hover:bg-p-line transition-colors"
-            >
-              {keyword}
-            </button>
-          ))}
-        </div>
-      )}
 
       <a
         href={getBrowserUrl(catalog.url)}

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -365,6 +365,17 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
         {/* Detail panel (bottom-left) */}
         {selected && (
           <div className="absolute bottom-3 start-3 z-10 w-[340px] max-w-[calc(100%-1.5rem)] bg-p-paper border border-p-line rounded-[var(--p-r-md)] p-4 shadow-[var(--p-shadow-lg)]">
+            {selected.logo && (
+              // Same reasoning as catalog-card: catalog-hosted logos have no
+              // finite host allowlist for next/image's remotePatterns.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={selected.logo.href}
+                alt={selected.logo.title ?? selected.title}
+                loading="lazy"
+                className="mb-2 h-6 w-auto max-w-[140px] object-contain"
+              />
+            )}
             <div className="flex items-start justify-between gap-2">
               <h3 className="text-card-title font-semibold line-clamp-2">
                 {selected.title}
@@ -393,8 +404,9 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
                 );
               })()}
             </div>
-            <p className="mt-3 text-body text-p-ink-2 line-clamp-2">
-              {selected.description}
+            <p className="mt-3 text-micro text-p-ink-3 font-mono">
+              {t("card.collections", { count: selected.collection_count })}
+              {selected.stac_version && ` · STAC ${selected.stac_version}`}
             </p>
             <a
               href={getBrowserUrl(selected.url)}

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -5,19 +5,27 @@ export interface CatalogValidation {
   has_llms_txt?: boolean;
 }
 
+// Read off the catalog's own `rel: "icon"` link. The registry resolves the
+// href against the catalog and confirms it points at an image a browser can
+// render, so the site can use it directly. Null for most catalogs.
+export interface CatalogLogo {
+  href: string;
+  type: string;
+  title?: string;
+}
+
 export interface Catalog {
   id: string;
   url: string;
   title: string;
-  description: string;
-  stac_version: string;
-  providers: unknown;
-  keywords: string[] | null;
+  stac_version: string | null;
   bbox: [number, number, number, number] | null;
-  license: string;
+  logo: CatalogLogo | null;
   collection_count: number;
   feature_count: number;
-  last_crawled: string;
+  // SPDX id -> how many collections declare it.
+  licenses: Record<string, number>;
+  last_crawled: string | null;
   validation: CatalogValidation;
 }
 
@@ -27,19 +35,71 @@ export interface CatalogsResponse {
   catalogs: Catalog[];
 }
 
-// Pinned to the last registry commit whose export still carried per-catalog
-// `bbox` (and the flat `catalogs` array this file parses). On 2026-06-30 the
-// registry reshaped the export into a STAC super-catalog and dropped spatial
-// extent entirely, which leaves the map with nothing to plot. Tracking the
-// restore in portolan-registry; unpin back to `main` once bboxes return.
-// https://github.com/portolan-sdi/portolan-registry/issues/36
+// The registry publishes its export as a STAC Catalog: one `rel="child"` link
+// per registered catalog, carrying the crawl's findings under a
+// `portolan_registry:` prefix. Schema:
+// https://github.com/portolan-sdi/portolan-registry/blob/main/schema/export.schema.json
+interface ChildLink {
+  rel: string;
+  href: string;
+  type?: string;
+  title?: string;
+  bbox?: [number, number, number, number] | null;
+  "portolan_registry:id": string;
+  "portolan_registry:stac_version"?: string | null;
+  "portolan_registry:logo"?: CatalogLogo | null;
+  "portolan_registry:collection_count"?: number | null;
+  "portolan_registry:feature_count"?: number | null;
+  "portolan_registry:licenses"?: Record<string, number> | null;
+  "portolan_registry:last_crawled"?: string | null;
+  "portolan_registry:stac_valid"?: boolean | null;
+  "portolan_registry:has_versions_json"?: boolean | null;
+  "portolan_registry:has_portolan_dir"?: boolean | null;
+  "portolan_registry:has_llms_txt"?: boolean | null;
+}
+
+interface RegistryExport {
+  generated: string;
+  count: number;
+  links: ChildLink[];
+}
+
 const CATALOGS_URL =
-  "https://raw.githubusercontent.com/portolan-sdi/portolan-registry/6f55bba64afe/exports/catalogs.json";
+  "https://raw.githubusercontent.com/portolan-sdi/portolan-registry/main/exports/catalogs.json";
 
 // Tag the registry fetch so the registry CI can invalidate it on demand
 // (POST /api/revalidate) the moment a new export is published, instead of
 // waiting out the hourly ISR window.
 export const CATALOGS_CACHE_TAG = "catalogs";
+
+function isBbox(value: unknown): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) && value.length === 4 && value.every((n) => typeof n === "number")
+  );
+}
+
+function toCatalog(link: ChildLink): Catalog {
+  const logo = link["portolan_registry:logo"];
+
+  return {
+    id: link["portolan_registry:id"],
+    url: link.href,
+    title: link.title ?? link["portolan_registry:id"],
+    stac_version: link["portolan_registry:stac_version"] ?? null,
+    bbox: isBbox(link.bbox) ? link.bbox : null,
+    logo: logo && logo.href ? logo : null,
+    collection_count: link["portolan_registry:collection_count"] ?? 0,
+    feature_count: link["portolan_registry:feature_count"] ?? 0,
+    licenses: link["portolan_registry:licenses"] ?? {},
+    last_crawled: link["portolan_registry:last_crawled"] ?? null,
+    validation: {
+      stac_valid: link["portolan_registry:stac_valid"] ?? false,
+      has_versions_json: link["portolan_registry:has_versions_json"] ?? false,
+      has_portolan_dir: link["portolan_registry:has_portolan_dir"] ?? false,
+      has_llms_txt: link["portolan_registry:has_llms_txt"] ?? false,
+    },
+  };
+}
 
 export async function getCatalogs(): Promise<CatalogsResponse> {
   const res = await fetch(CATALOGS_URL, {
@@ -50,7 +110,16 @@ export async function getCatalogs(): Promise<CatalogsResponse> {
     throw new Error(`Failed to fetch catalogs: ${res.status}`);
   }
 
-  return res.json();
+  const data: RegistryExport = await res.json();
+  const catalogs = (data.links ?? [])
+    .filter((link) => link.rel === "child" && link["portolan_registry:id"])
+    .map(toCatalog);
+
+  return {
+    generated: data.generated,
+    count: catalogs.length,
+    catalogs,
+  };
 }
 
 // The Portolan browser opens any catalog.json via a hash route that carries the
@@ -75,4 +144,15 @@ export function getValidationTier(validation: CatalogValidation): "unvalidated" 
     return "basic";
   }
   return "unvalidated";
+}
+
+// The export reports licenses as an SPDX id -> collection count map. One id is
+// worth naming; several only warrant a count.
+export function getLicenseSummary(
+  licenses: Record<string, number>
+): { kind: "single"; id: string } | { kind: "many"; count: number } | null {
+  const ids = Object.keys(licenses);
+  if (ids.length === 0) return null;
+  if (ids.length === 1) return { kind: "single", id: ids[0] };
+  return { kind: "many", count: ids.length };
 }


### PR DESCRIPTION
## Why

The registry publishes a logo for every catalog that declares one, and nothing on the site read it. `getCatalogs` was also pinned to a June commit predating the STAC super-catalog reshape, so the listing advertised four catalogs while the registry carried six. Resolves #45.

## What this changes

`CATALOGS_URL` points at `main`, and `getCatalogs` parses the `rel="child"` links and their `portolan_registry:` fields. The catalog card and map detail panel render the logo, falling back to the title alone. The export no longer carries `description` or `keywords`, so the card drops both along with the tag filter they fed, and shows the license summary instead. Logos load through a plain `<img>`: catalogs live on arbitrary hosts, so `next/image` would need a wildcard `remotePatterns` entry.

## Verification

Built and served against the live export at `https://raw.githubusercontent.com/portolan-sdi/portolan-registry/main/exports/catalogs.json`. The count now tracks the registry.

```console
$ curl -s https://raw.githubusercontent.com/portolan-sdi/portolan-registry/main/exports/catalogs.json -o live.json
$ grep -c '"rel": "child"' live.json
6
$ pnpm build && pnpm start -p 3517
$ curl -s http://localhost:3517/ | grep -o "Browse [0-9]* catalogs"
Browse 6 catalogs
```

Each card carries collections, STAC version, license, and centroid:

```console
Capas de Referencia del Instituto Geográfico Nacional de Argentina · 192 collections · STAC 1.1.0 · other · 12S, 0E
JRC GloFAS Global Flood Hazard Maps · 16 collections · STAC 1.1.0 · proprietary · 10N, 5E
pergamino-ide · 178 collections · STAC 1.1.0 · proprietary · 34S, 60W
Portolan NL — Cloud-Native Dutch Geodata · 34 collections · STAC 1.1.0 · 3 licenses · 53N, 5E
TriMet Geospatial Data · 8 collections · STAC 1.1.0 · other · 45N, 123W
Planet Crisis Response — Venezuela Earthquake, June 2026 · 2 collections · STAC 1.1.0 · CC-BY-NC-4.0 · 10N, 67W
```

The live export carries no logos yet. portolan-sdi/portolan-registry#59 merged, but every `Publish Catalog Export` run since then fails to push, so the published export predates it. Logo rendering was checked against the two real `rel: "icon"` links those catalogs serve today.

```console
$ curl -s https://data.source.coop/cholmes/trimet/catalog.json | jq -c '.links[]|select(.rel=="icon")'
{"rel":"icon","href":"./_assets/trimet-logo.png","type":"image/png","title":"TriMet"}
$ curl -sI https://data.source.coop/cholmes/trimet/_assets/trimet-logo.png | head -1
HTTP/2 200

# both logos decoded in the rendered card grid
[{"src":".../rijksoverheid.png","alt":"Rijksoverheid logo","naturalWidth":100,"height":32},
 {"src":".../trimet-logo.png","alt":"TriMet","naturalWidth":256,"height":32}]
```
