### PR TITLE
feat(registry): rebuild the catalog cards, map, and section copy

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -119,7 +119,6 @@
   },
   "registry": {
     "title": "تصفّح {count} كتالوج",
-    "description": "كتالوجات منشورة من جميع أنحاء العالم، مباشرة من السجل.",
     "search": {
       "placeholder": "ابحث في الكتالوجات...",
       "noResults": "لا توجد كتالوجات تطابق بحثك",
@@ -128,34 +127,30 @@
     "filters": {
       "tags": "الوسوم",
       "access": "الوصول",
-      "validation": "التحقق",
-      "all": "الكل",
-      "bbox": "المنطقة",
-      "bboxLabel": "الإطار المحدد (WGS84)",
-      "lonPlaceholder": "lon",
-      "latPlaceholder": "lat"
-    },
-    "compass": {
-      "north": "N",
-      "south": "S",
-      "east": "E",
-      "west": "W"
+      "kind": "نوع الكتالوج",
+      "allKinds": "كل الأنواع"
     },
     "access": {
       "public": "عام",
       "authenticated": "مصادق عليه"
     },
     "validation": {
-      "unvalidated": "غير موثق",
-      "basic": "أساسي",
-      "full": "كامل"
+      "unvalidated": "غير موثق"
     },
     "card": {
       "maintainer": "يديره",
       "submitted": "أُرسل",
       "viewCatalog": "عرض الكتالوج",
-      "collections": "{count, plural, other {# مجموعة}}",
-      "licenses": "{count, plural, other {# رخصة}}"
+      "collections": "{count} مجموعة",
+      "licenses": "{count} رخصة",
+      "collection": "مجموعة واحدة",
+      "features": "{count} معلم",
+      "items": "{count} عنصر",
+      "specVersion": "portolan {version}",
+      "updated": "حُدّث في {date}",
+      "copyUrl": "نسخ العنوان",
+      "copied": "تم النسخ",
+      "noLocation": "لا يوجد موقع مُعلن"
     },
     "cta": {
       "title": "هل لديك كتالوج لمشاركته؟",
@@ -187,16 +182,27 @@
       "noSearchResults": "لم يتم العثور على أماكن",
       "zoomIn": "تكبير",
       "zoomOut": "تصغير",
-      "info": "معلومات الخريطة",
       "reset": "إعادة ضبط العرض",
-      "infoBody": "خريطة الأساس © CARTO و© OpenStreetMap والمساهمون فيها. البحث مدعوم من Nominatim. تظهر الكتالوجات كنقاط. كبّر الخريطة لرؤية مناطق تغطيتها.",
       "closeDetails": "إغلاق التفاصيل",
-      "noLocation": "{count, plural, other {# كتالوج بدون بيانات موقع}}",
-      "loading": "جارٍ تحميل الخريطة..."
+      "noLocation": "{count} بدون موقع",
+      "loading": "جارٍ تحميل الخريطة...",
+      "worldwide": "عالمي",
+      "legend": {
+        "dot": "الموقع",
+        "area": "التغطية",
+        "wide": "تغطية واسعة"
+      }
     },
     "generated": "آخر تحديث {date}",
-    "caption": "الكتالوجات المنشورة حسب الموقع",
-    "captionNote": "{count} معروضة · مباشرة من السجل"
+    "captionFiltered": "{shown} من {total} معروضة",
+    "captionCrawled": "جُمعت في {date}",
+    "kind": {
+      "official": "رسمي",
+      "mirror": "نسخة مرآة"
+    },
+    "status": {
+      "stale": "قديم"
+    }
   },
   "resources": {
     "eyebrow": "محاضرات وتجارب",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -150,7 +150,9 @@
       "updated": "حُدّث في {date}",
       "copyUrl": "نسخ العنوان",
       "copied": "تم النسخ",
-      "noLocation": "لا يوجد موقع مُعلن"
+      "noLocation": "لا يوجد موقع مُعلن",
+      "showDetails": "التفاصيل",
+      "hideDetails": "إخفاء التفاصيل"
     },
     "cta": {
       "title": "هل لديك كتالوج لمشاركته؟",
@@ -186,23 +188,25 @@
       "closeDetails": "إغلاق التفاصيل",
       "noLocation": "{count} بدون موقع",
       "loading": "جارٍ تحميل الخريطة...",
-      "worldwide": "عالمي",
-      "legend": {
-        "dot": "الموقع",
-        "area": "التغطية",
-        "wide": "تغطية واسعة"
-      }
+      "info": "حقوق الخريطة"
     },
     "generated": "آخر تحديث {date}",
-    "captionFiltered": "{shown} من {total} معروضة",
-    "captionCrawled": "جُمعت في {date}",
     "kind": {
       "official": "رسمي",
       "mirror": "نسخة مرآة"
     },
     "status": {
       "stale": "قديم"
-    }
+    },
+    "global": {
+      "title": "بيانات عالمية"
+    },
+    "pagination": {
+      "prev": "الصفحة السابقة",
+      "next": "الصفحة التالية",
+      "status": "{page} / {total}"
+    },
+    "lastChecked": "آخر مراجعة {date}"
   },
   "resources": {
     "eyebrow": "محاضرات وتجارب",

--- a/messages/en.json
+++ b/messages/en.json
@@ -119,7 +119,6 @@
   },
   "registry": {
     "title": "Browse {count} catalogs",
-    "description": "Catalogs published around the world, live in the registry.",
     "search": {
       "placeholder": "Search catalogs...",
       "noResults": "No catalogs match your search",
@@ -128,34 +127,30 @@
     "filters": {
       "tags": "Tags",
       "access": "Access",
-      "validation": "Validation",
-      "all": "All",
-      "bbox": "Region",
-      "bboxLabel": "Bounding box (WGS84)",
-      "lonPlaceholder": "lon",
-      "latPlaceholder": "lat"
-    },
-    "compass": {
-      "north": "N",
-      "south": "S",
-      "east": "E",
-      "west": "W"
+      "kind": "Catalog type",
+      "allKinds": "All types"
     },
     "access": {
       "public": "Public",
       "authenticated": "Authenticated"
     },
     "validation": {
-      "unvalidated": "Unvalidated",
-      "basic": "Basic",
-      "full": "Full"
+      "unvalidated": "Unvalidated"
     },
     "card": {
       "maintainer": "Maintained by",
       "submitted": "Submitted",
       "viewCatalog": "View catalog",
-      "collections": "{count, plural, one {# collection} other {# collections}}",
-      "licenses": "{count, plural, one {# license} other {# licenses}}"
+      "collections": "{count} collections",
+      "licenses": "{count} licenses",
+      "collection": "1 collection",
+      "features": "{count} features",
+      "items": "{count} items",
+      "specVersion": "portolan {version}",
+      "updated": "updated {date}",
+      "copyUrl": "Copy address",
+      "copied": "Copied",
+      "noLocation": "No location reported"
     },
     "cta": {
       "title": "Have a catalog to share?",
@@ -187,16 +182,27 @@
       "noSearchResults": "No places found",
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
-      "info": "Map information",
       "reset": "Reset view",
-      "infoBody": "Basemap © CARTO, © OpenStreetMap contributors. Search powered by Nominatim. Catalogs appear as dots. Zoom in to see their coverage areas.",
       "closeDetails": "Close details",
-      "noLocation": "{count, plural, one {# catalog has no location data} other {# catalogs have no location data}}",
-      "loading": "Loading map..."
+      "noLocation": "{count} without location",
+      "loading": "Loading map...",
+      "worldwide": "Worldwide",
+      "legend": {
+        "dot": "Location",
+        "area": "Coverage",
+        "wide": "Wide coverage"
+      }
     },
     "generated": "Last updated: {date}",
-    "caption": "Published catalogs by location",
-    "captionNote": "{count} shown · live from the registry"
+    "captionFiltered": "{shown} of {total} shown",
+    "captionCrawled": "crawled {date}",
+    "kind": {
+      "official": "Official",
+      "mirror": "Mirror"
+    },
+    "status": {
+      "stale": "Stale"
+    }
   },
   "resources": {
     "eyebrow": "Talks & demos",

--- a/messages/en.json
+++ b/messages/en.json
@@ -150,7 +150,9 @@
       "updated": "updated {date}",
       "copyUrl": "Copy address",
       "copied": "Copied",
-      "noLocation": "No location reported"
+      "noLocation": "No location reported",
+      "showDetails": "Details",
+      "hideDetails": "Hide details"
     },
     "cta": {
       "title": "Have a catalog to share?",
@@ -186,23 +188,25 @@
       "closeDetails": "Close details",
       "noLocation": "{count} without location",
       "loading": "Loading map...",
-      "worldwide": "Worldwide",
-      "legend": {
-        "dot": "Location",
-        "area": "Coverage",
-        "wide": "Wide coverage"
-      }
+      "info": "Map credits"
     },
     "generated": "Last updated: {date}",
-    "captionFiltered": "{shown} of {total} shown",
-    "captionCrawled": "crawled {date}",
     "kind": {
       "official": "Official",
       "mirror": "Mirror"
     },
     "status": {
       "stale": "Stale"
-    }
+    },
+    "global": {
+      "title": "Global datasets"
+    },
+    "pagination": {
+      "prev": "Previous page",
+      "next": "Next page",
+      "status": "{page} / {total}"
+    },
+    "lastChecked": "Last checked: {date}"
   },
   "resources": {
     "eyebrow": "Talks & demos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -150,7 +150,9 @@
       "updated": "actualizado el {date}",
       "copyUrl": "Copiar dirección",
       "copied": "Copiado",
-      "noLocation": "Sin ubicación declarada"
+      "noLocation": "Sin ubicación declarada",
+      "showDetails": "Detalles",
+      "hideDetails": "Ocultar detalles"
     },
     "cta": {
       "title": "¿Tienes un catálogo para compartir?",
@@ -186,23 +188,25 @@
       "closeDetails": "Cerrar detalles",
       "noLocation": "{count} sin ubicación",
       "loading": "Cargando mapa...",
-      "worldwide": "Mundial",
-      "legend": {
-        "dot": "Ubicación",
-        "area": "Cobertura",
-        "wide": "Cobertura amplia"
-      }
+      "info": "Créditos del mapa"
     },
     "generated": "Última actualización {date}",
-    "captionFiltered": "{shown} de {total} mostrados",
-    "captionCrawled": "rastreado el {date}",
     "kind": {
       "official": "Oficial",
       "mirror": "Espejo"
     },
     "status": {
       "stale": "Obsoleto"
-    }
+    },
+    "global": {
+      "title": "Datos globales"
+    },
+    "pagination": {
+      "prev": "Página anterior",
+      "next": "Página siguiente",
+      "status": "{page} / {total}"
+    },
+    "lastChecked": "Última revisión {date}"
   },
   "resources": {
     "eyebrow": "Charlas y demos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -119,7 +119,6 @@
   },
   "registry": {
     "title": "Explora {count} catálogos",
-    "description": "Catálogos publicados en todo el mundo, en directo desde el registro.",
     "search": {
       "placeholder": "Buscar catálogos...",
       "noResults": "Ningún catálogo coincide con tu búsqueda",
@@ -128,34 +127,30 @@
     "filters": {
       "tags": "Etiquetas",
       "access": "Acceso",
-      "validation": "Validación",
-      "all": "Todos",
-      "bbox": "Región",
-      "bboxLabel": "Caja delimitadora (WGS84)",
-      "lonPlaceholder": "lon",
-      "latPlaceholder": "lat"
-    },
-    "compass": {
-      "north": "N",
-      "south": "S",
-      "east": "E",
-      "west": "O"
+      "kind": "Tipo de catálogo",
+      "allKinds": "Todos los tipos"
     },
     "access": {
       "public": "Público",
       "authenticated": "Autenticado"
     },
     "validation": {
-      "unvalidated": "Sin validar",
-      "basic": "Básico",
-      "full": "Completo"
+      "unvalidated": "Sin validar"
     },
     "card": {
       "maintainer": "Mantenido por",
       "submitted": "Enviado",
       "viewCatalog": "Ver catálogo",
-      "collections": "{count, plural, one {# colección} other {# colecciones}}",
-      "licenses": "{count, plural, one {# licencia} other {# licencias}}"
+      "collections": "{count} colecciones",
+      "licenses": "{count} licencias",
+      "collection": "1 colección",
+      "features": "{count} entidades",
+      "items": "{count} elementos",
+      "specVersion": "portolan {version}",
+      "updated": "actualizado el {date}",
+      "copyUrl": "Copiar dirección",
+      "copied": "Copiado",
+      "noLocation": "Sin ubicación declarada"
     },
     "cta": {
       "title": "¿Tienes un catálogo para compartir?",
@@ -187,16 +182,27 @@
       "noSearchResults": "No se encontraron lugares",
       "zoomIn": "Acercar",
       "zoomOut": "Alejar",
-      "info": "Información del mapa",
       "reset": "Restablecer vista",
-      "infoBody": "Mapa base © CARTO, © OpenStreetMap y sus colaboradores. Búsqueda proporcionada por Nominatim. Los catálogos aparecen como puntos. Acerca el mapa para ver sus áreas de cobertura.",
       "closeDetails": "Cerrar detalles",
-      "noLocation": "{count, plural, one {# catálogo sin datos de ubicación} other {# catálogos sin datos de ubicación}}",
-      "loading": "Cargando mapa..."
+      "noLocation": "{count} sin ubicación",
+      "loading": "Cargando mapa...",
+      "worldwide": "Mundial",
+      "legend": {
+        "dot": "Ubicación",
+        "area": "Cobertura",
+        "wide": "Cobertura amplia"
+      }
     },
     "generated": "Última actualización {date}",
-    "caption": "Catálogos publicados por ubicación",
-    "captionNote": "{count} mostrados · en vivo desde el registro"
+    "captionFiltered": "{shown} de {total} mostrados",
+    "captionCrawled": "rastreado el {date}",
+    "kind": {
+      "official": "Oficial",
+      "mirror": "Espejo"
+    },
+    "status": {
+      "stale": "Obsoleto"
+    }
   },
   "resources": {
     "eyebrow": "Charlas y demos",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -500,10 +500,12 @@ body {
 .tk-flip:focus-within .tk-flip__inner {
   transform: rotateY(180deg);
 }
-/* Catalog cards carry controls on both faces, so they cannot turn on hover.
-   Reaching a link on the front would turn the card away from the pointer. They
-   turn on click instead and record it in React state. Rule order matters: the
-   data-flipped rule has to come after the hover reset to win when both match. */
+/* Catalog cards carry controls on both faces, so React owns their turn rather
+   than CSS: it has to know which face is showing to keep the hidden one out of
+   the tab order. Hover, tap, and keyboard focus all set data-flipped. The two
+   rules below drop the shared hover behaviour and read that attribute instead.
+   Order matters, since the data-flipped rule has to come after the hover reset
+   to win when a pointer is over a card that is already turned. */
 .tk-flip--manual:hover .tk-flip__inner,
 .tk-flip--manual:focus-within .tk-flip__inner {
   transform: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -500,6 +500,17 @@ body {
 .tk-flip:focus-within .tk-flip__inner {
   transform: rotateY(180deg);
 }
+/* Catalog cards carry controls on both faces, so they cannot turn on hover.
+   Reaching a link on the front would turn the card away from the pointer. They
+   turn on click instead and record it in React state. Rule order matters: the
+   data-flipped rule has to come after the hover reset to win when both match. */
+.tk-flip--manual:hover .tk-flip__inner,
+.tk-flip--manual:focus-within .tk-flip__inner {
+  transform: none;
+}
+.tk-flip--manual .tk-flip__inner[data-flipped="true"] {
+  transform: rotateY(180deg);
+}
 .tk-flip__face {
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -14,9 +14,13 @@ import { PipelineFigure } from "./pipeline-figure";
 import { Btn, DirArrow, Ltr, SectionHead, monoChunk } from "./ui";
 import { CatalogCard } from "./registry/catalog-card";
 import type { Catalog, CatalogKind } from "@/lib/catalogs";
-import { formatDate } from "@/lib/catalogs";
+import { formatDate, getCoverageTier } from "@/lib/catalogs";
 
 type SubmitState = "idle" | "submitting" | "success" | "error";
+
+// Two rows of three on a wide screen. Small enough that the control is real
+// at the registry's current size rather than appearing only after it doubles.
+const CARDS_PER_PAGE = 6;
 
 // Placeholder shown while the deck.gl/maplibre chunk loads on first map view.
 function MapSkeleton() {
@@ -53,6 +57,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [kindFilter, setKindFilter] = useState<"all" | CatalogKind>("all");
   const [registryView, setRegistryView] = useState<"cards" | "map">("map");
+  const [rawPage, setPage] = useState(0);
 
   const [submitUrl, setSubmitUrl] = useState("");
   const [submitEmail, setSubmitEmail] = useState("");
@@ -111,9 +116,30 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
     });
   }, [catalogs, searchQuery, kindFilter]);
 
+  // A catalog claiming most of the globe would cover every located one beneath
+  // it and drag the initial map fit out to the whole world. Those get their own
+  // block under the map, where their titles are readable.
+  const { mappableCatalogs, globalCatalogs } = useMemo(() => {
+    const mappable: Catalog[] = [];
+    const global: Catalog[] = [];
+    for (const catalog of filteredCatalogs) {
+      (getCoverageTier(catalog.bbox) === "global" ? global : mappable).push(catalog);
+    }
+    return { mappableCatalogs: mappable, globalCatalogs: global };
+  }, [filteredCatalogs]);
+
+  const pageCount = Math.max(1, Math.ceil(filteredCatalogs.length / CARDS_PER_PAGE));
+  // Filtering can shrink the list under the current page.
+  const page = Math.min(rawPage, pageCount - 1);
+  const pagedCatalogs = filteredCatalogs.slice(
+    page * CARDS_PER_PAGE,
+    page * CARDS_PER_PAGE + CARDS_PER_PAGE
+  );
+
   const handleClearFilters = () => {
     setSearchQuery("");
     setKindFilter("all");
+    setPage(0);
   };
 
   const hasActiveFilters = searchQuery !== "" || kindFilter !== "all";
@@ -333,9 +359,26 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
         <section id="registry" className="px-[var(--p-pad-section-x)] py-[var(--p-pad-section-y)]">
           <div className="max-w-[1240px] mx-auto">
             {/* No eyebrow and no subtitle: the title ("Browse N catalogs")
-                already names the section, and the caption under the map
-                carries the only other fact worth stating. */}
+                already names the section. */}
             <SectionHead title={t("registry.title", { count: catalogs.length })} wide />
+
+            {/* Where the listing comes from and when it was last read. */}
+            <p className="-mt-[clamp(1.5rem,3vw,2.5rem)] mb-8 flex flex-wrap items-center gap-x-1.5 font-mono text-eyebrow text-p-ink-3">
+              <a
+                href="https://github.com/portolan-sdi/portolan-registry"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-p-primary hover:underline"
+              >
+                <Ltr>portolan-registry</Ltr> ↗
+              </a>
+              {crawledAt && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>{t("registry.lastChecked", { date: crawledAt })}</span>
+                </>
+              )}
+            </p>
 
             {/* Filters */}
             <div className="space-y-4 mb-8">
@@ -409,13 +452,71 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
 
             {/* Catalog view: map or grid */}
             {registryView === "map" ? (
-              <CatalogMap catalogs={filteredCatalogs} />
+              <>
+                <CatalogMap catalogs={mappableCatalogs} />
+                {globalCatalogs.length > 0 && (
+                  <div className="mt-10 border-t border-p-line pt-8">
+                    <h3 className="text-card-title-lg font-semibold">
+                      {t("registry.global.title")}
+                    </h3>
+                    <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                      {globalCatalogs.map((catalog) => (
+                        <CatalogCard key={catalog.id} catalog={catalog} />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
             ) : filteredCatalogs.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                {filteredCatalogs.map((catalog) => (
-                  <CatalogCard key={catalog.id} catalog={catalog} />
-                ))}
-              </div>
+              <>
+                {/* A short last page must not shrink the grid, or everything
+                    below it jumps when you change page. Cards are 260px with a
+                    20px gap, so two rows reserve 540 and three reserve 820.
+                    Single-column screens are left alone: reserving six rows
+                    there would leave a screenful of blank under a short page,
+                    and the whole grid is taller than the viewport anyway. */}
+                <div
+                  className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 ${
+                    pageCount > 1 ? "md:min-h-[820px] lg:min-h-[540px]" : ""
+                  }`}
+                >
+                  {pagedCatalogs.map((catalog) => (
+                    <CatalogCard key={catalog.id} catalog={catalog} />
+                  ))}
+                </div>
+                {pageCount > 1 && (
+                  <div className="mt-8 flex items-center justify-end gap-4">
+                    <span className="font-mono text-micro text-p-ink-3">
+                      {t("registry.pagination.status", {
+                        page: String(page + 1),
+                        total: String(pageCount),
+                      })}
+                    </span>
+                    <div className="flex border border-p-line" role="group">
+                      <button
+                        type="button"
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                        disabled={page === 0}
+                        aria-label={t("registry.pagination.prev")}
+                        className="px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+                      >
+                        <span aria-hidden="true" className="rtl:hidden">&#8249;</span>
+                        <span aria-hidden="true" className="hidden rtl:inline">&#8250;</span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                        disabled={page >= pageCount - 1}
+                        aria-label={t("registry.pagination.next")}
+                        className="border-s border-p-line px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+                      >
+                        <span aria-hidden="true" className="rtl:hidden">&#8250;</span>
+                        <span aria-hidden="true" className="hidden rtl:inline">&#8249;</span>
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </>
             ) : (
               <div className="text-center py-12">
                 <p className="text-body text-p-ink-2">{t("registry.search.noResults")}</p>
@@ -428,28 +529,6 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                 </button>
               </div>
             )}
-
-            {/* Annotation row: same anatomy as a figure caption. It names the
-                source of the data and how fresh it is, which nothing else on
-                the page says. */}
-            <div className="flex flex-wrap justify-between gap-x-3 gap-y-1 mt-3 pt-2 border-t border-p-line-soft font-mono text-eyebrow text-p-ink-3">
-              <a
-                href="https://github.com/portolan-sdi/portolan-registry"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-p-primary hover:underline"
-              >
-                <Ltr>portolan-sdi/portolan-registry</Ltr> ↗
-              </a>
-              <span>
-                {filteredCatalogs.length < catalogs.length &&
-                  `${t("registry.captionFiltered", {
-                    shown: String(filteredCatalogs.length),
-                    total: String(catalogs.length),
-                  })} · `}
-                {crawledAt && t("registry.captionCrawled", { date: crawledAt })}
-              </span>
-            </div>
 
             {/* Inline Submit */}
             <div className="mt-10 bg-p-paper border border-p-line rounded-[var(--p-r-lg)] p-6">

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -22,6 +22,54 @@ type SubmitState = "idle" | "submitting" | "success" | "error";
 // at the registry's current size rather than appearing only after it doubles.
 const CARDS_PER_PAGE = 6;
 
+// The global block sits under the map and stays one row on a wide screen.
+const GLOBAL_PER_PAGE = 3;
+
+// Page control shared by the card grid and the global block. Mirrors the arrows
+// on the talks row rather than introducing a second pagination idiom.
+function Pager({
+  page,
+  pageCount,
+  onChange,
+}: {
+  page: number;
+  pageCount: number;
+  onChange: (next: number) => void;
+}) {
+  const t = useTranslations("registry.pagination");
+  if (pageCount <= 1) return null;
+
+  return (
+    <div className="mt-8 flex items-center justify-end gap-4">
+      <span className="font-mono text-micro text-p-ink-3">
+        {t("status", { page: String(page + 1), total: String(pageCount) })}
+      </span>
+      <div className="flex border border-p-line">
+        <button
+          type="button"
+          onClick={() => onChange(page - 1)}
+          disabled={page === 0}
+          aria-label={t("prev")}
+          className="px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+        >
+          <span aria-hidden="true" className="rtl:hidden">&#8249;</span>
+          <span aria-hidden="true" className="hidden rtl:inline">&#8250;</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(page + 1)}
+          disabled={page >= pageCount - 1}
+          aria-label={t("next")}
+          className="border-s border-p-line px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
+        >
+          <span aria-hidden="true" className="rtl:hidden">&#8250;</span>
+          <span aria-hidden="true" className="hidden rtl:inline">&#8249;</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // Placeholder shown while the deck.gl/maplibre chunk loads on first map view.
 function MapSkeleton() {
   const t = useTranslations("registry");
@@ -58,6 +106,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const [kindFilter, setKindFilter] = useState<"all" | CatalogKind>("all");
   const [registryView, setRegistryView] = useState<"cards" | "map">("map");
   const [rawPage, setPage] = useState(0);
+  const [rawGlobalPage, setGlobalPage] = useState(0);
 
   const [submitUrl, setSubmitUrl] = useState("");
   const [submitEmail, setSubmitEmail] = useState("");
@@ -134,6 +183,13 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const pagedCatalogs = filteredCatalogs.slice(
     page * CARDS_PER_PAGE,
     page * CARDS_PER_PAGE + CARDS_PER_PAGE
+  );
+
+  const globalPageCount = Math.max(1, Math.ceil(globalCatalogs.length / GLOBAL_PER_PAGE));
+  const globalPage = Math.min(rawGlobalPage, globalPageCount - 1);
+  const pagedGlobalCatalogs = globalCatalogs.slice(
+    globalPage * GLOBAL_PER_PAGE,
+    globalPage * GLOBAL_PER_PAGE + GLOBAL_PER_PAGE
   );
 
   const handleClearFilters = () => {
@@ -459,11 +515,23 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                     <h3 className="text-card-title-lg font-semibold">
                       {t("registry.global.title")}
                     </h3>
-                    <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                      {globalCatalogs.map((catalog) => (
+                    {/* One row on a wide screen. Three cards in two columns
+                        wrap to two rows at md, so that height is reserved
+                        instead. */}
+                    <div
+                      className={`mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 ${
+                        globalPageCount > 1 ? "md:min-h-[540px] lg:min-h-[260px]" : ""
+                      }`}
+                    >
+                      {pagedGlobalCatalogs.map((catalog) => (
                         <CatalogCard key={catalog.id} catalog={catalog} />
                       ))}
                     </div>
+                    <Pager
+                      page={globalPage}
+                      pageCount={globalPageCount}
+                      onChange={setGlobalPage}
+                    />
                   </div>
                 )}
               </>
@@ -484,38 +552,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                     <CatalogCard key={catalog.id} catalog={catalog} />
                   ))}
                 </div>
-                {pageCount > 1 && (
-                  <div className="mt-8 flex items-center justify-end gap-4">
-                    <span className="font-mono text-micro text-p-ink-3">
-                      {t("registry.pagination.status", {
-                        page: String(page + 1),
-                        total: String(pageCount),
-                      })}
-                    </span>
-                    <div className="flex border border-p-line" role="group">
-                      <button
-                        type="button"
-                        onClick={() => setPage((p) => Math.max(0, p - 1))}
-                        disabled={page === 0}
-                        aria-label={t("registry.pagination.prev")}
-                        className="px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
-                      >
-                        <span aria-hidden="true" className="rtl:hidden">&#8249;</span>
-                        <span aria-hidden="true" className="hidden rtl:inline">&#8250;</span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-                        disabled={page >= pageCount - 1}
-                        aria-label={t("registry.pagination.next")}
-                        className="border-s border-p-line px-3 py-1.5 text-p-ink transition-colors hover:bg-p-bg-soft disabled:text-p-ink-3 disabled:hover:bg-transparent cursor-pointer disabled:cursor-default"
-                      >
-                        <span aria-hidden="true" className="rtl:hidden">&#8250;</span>
-                        <span aria-hidden="true" className="hidden rtl:inline">&#8249;</span>
-                      </button>
-                    </div>
-                  </div>
-                )}
+                <Pager page={page} pageCount={pageCount} onChange={setPage} />
               </>
             ) : (
               <div className="text-center py-12">

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -13,8 +13,8 @@ import { InvolvedSection } from "./involved-section";
 import { PipelineFigure } from "./pipeline-figure";
 import { Btn, DirArrow, Ltr, SectionHead, monoChunk } from "./ui";
 import { CatalogCard } from "./registry/catalog-card";
-import type { Catalog } from "@/lib/catalogs";
-import { getValidationTier } from "@/lib/catalogs";
+import type { Catalog, CatalogKind } from "@/lib/catalogs";
+import { formatDate } from "@/lib/catalogs";
 
 type SubmitState = "idle" | "submitting" | "success" | "error";
 
@@ -51,11 +51,7 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
   const locale = useLocale();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [validationFilter, setValidationFilter] = useState<"all" | "unvalidated" | "basic" | "full">("all");
-  const [bboxFilter, setBboxFilter] = useState<{ west: string; south: string; east: string; north: string }>({
-    west: "", south: "", east: "", north: ""
-  });
-  const [showBboxFilter, setShowBboxFilter] = useState(false);
+  const [kindFilter, setKindFilter] = useState<"all" | CatalogKind>("all");
   const [registryView, setRegistryView] = useState<"cards" | "map">("map");
 
   const [submitUrl, setSubmitUrl] = useState("");
@@ -91,47 +87,38 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
     ];
   }, [catalogs, locale]);
 
-  const parsedBbox = useMemo(() => {
-    const { west, south, east, north } = bboxFilter;
-    if (!west && !south && !east && !north) return null;
-    const w = parseFloat(west);
-    const s = parseFloat(south);
-    const e = parseFloat(east);
-    const n = parseFloat(north);
-    if ([w, s, e, n].some(isNaN)) return null;
-    return { west: w, south: s, east: e, north: n };
-  }, [bboxFilter]);
+  // The registry does not export whether a catalog is the official copy or a
+  // mirror yet, so every entry reports null and this set stays empty. The
+  // control appears on its own once the export carries the field.
+  const availableKinds = useMemo(() => {
+    return Array.from(
+      new Set(catalogs.map((c) => c.kind).filter((k): k is CatalogKind => k !== null))
+    );
+  }, [catalogs]);
 
   const filteredCatalogs = useMemo(() => {
     return catalogs.filter((catalog) => {
-      const query = searchQuery.toLowerCase();
-      const matchesSearch = query === "" || catalog.title.toLowerCase().includes(query);
+      const query = searchQuery.trim().toLowerCase();
+      const matchesSearch =
+        query === "" ||
+        catalog.title.toLowerCase().includes(query) ||
+        catalog.id.toLowerCase().includes(query) ||
+        Object.keys(catalog.licenses).some((id) => id.toLowerCase().includes(query));
 
-      const tier = getValidationTier(catalog.validation);
-      const matchesValidation =
-        validationFilter === "all" || tier === validationFilter;
+      const matchesKind = kindFilter === "all" || catalog.kind === kindFilter;
 
-      let matchesBbox = true;
-      if (parsedBbox && catalog.bbox) {
-        const [catWest, catSouth, catEast, catNorth] = catalog.bbox;
-        matchesBbox =
-          catEast >= parsedBbox.west &&
-          catWest <= parsedBbox.east &&
-          catNorth >= parsedBbox.south &&
-          catSouth <= parsedBbox.north;
-      }
-
-      return matchesSearch && matchesValidation && matchesBbox;
+      return matchesSearch && matchesKind;
     });
-  }, [catalogs, searchQuery, validationFilter, parsedBbox]);
+  }, [catalogs, searchQuery, kindFilter]);
 
   const handleClearFilters = () => {
     setSearchQuery("");
-    setValidationFilter("all");
-    setBboxFilter({ west: "", south: "", east: "", north: "" });
+    setKindFilter("all");
   };
 
-  const hasActiveFilters = searchQuery !== "" || validationFilter !== "all" || parsedBbox !== null;
+  const hasActiveFilters = searchQuery !== "" || kindFilter !== "all";
+
+  const crawledAt = formatDate(catalogs[0]?.last_crawled ?? null, locale);
 
   const handleSubmitCatalog = async () => {
     if (!canSubmit || submitState === "submitting") return;
@@ -345,11 +332,10 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
       {catalogs.length > 0 && (
         <section id="registry" className="px-[var(--p-pad-section-x)] py-[var(--p-pad-section-y)]">
           <div className="max-w-[1240px] mx-auto">
-            {/* No eyebrow: the title ("Browse N catalogs") already names the section. */}
-            <SectionHead
-              title={t("registry.title", { count: catalogs.length })}
-              subtitle={t("registry.description")}
-            />
+            {/* No eyebrow and no subtitle: the title ("Browse N catalogs")
+                already names the section, and the caption under the map
+                carries the only other fact worth stating. */}
+            <SectionHead title={t("registry.title", { count: catalogs.length })} wide />
 
             {/* Filters */}
             <div className="space-y-4 mb-8">
@@ -359,41 +345,33 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder={t("registry.search.placeholder")}
-                  className="flex-1 bg-p-paper border border-p-line rounded-[var(--p-r-md)] px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none focus:border-p-primary transition-colors"
+                  className="flex-1 bg-p-paper border border-p-line px-4 py-2.5 text-body text-p-ink placeholder:text-p-ink-3 focus:outline-none focus:border-p-primary transition-colors"
                 />
-                <div className="relative">
-                  <select
-                    value={validationFilter}
-                    onChange={(e) => setValidationFilter(e.target.value as typeof validationFilter)}
-                    className="appearance-none bg-p-paper border border-p-line rounded-[var(--p-r-md)] pl-3 pr-8 py-2.5 text-body text-p-ink focus:outline-none focus:border-p-primary transition-colors cursor-pointer"
-                    aria-label={t("registry.filters.validation")}
-                  >
-                    <option value="all">{t("registry.filters.all")}</option>
-                    <option value="unvalidated">{t("registry.validation.unvalidated")}</option>
-                    <option value="basic">{t("registry.validation.basic")}</option>
-                    <option value="full">{t("registry.validation.full")}</option>
-                  </select>
-                  <svg className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-p-ink-3 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setShowBboxFilter(!showBboxFilter)}
-                  className={`flex items-center gap-2 px-3 py-2.5 text-body border rounded-[var(--p-r-md)] transition-colors ${
-                    showBboxFilter || parsedBbox
-                      ? "bg-[color-mix(in_oklab,var(--p-primary)_10%,transparent)] border-[color-mix(in_oklab,var(--p-primary)_25%,transparent)] text-p-primary-ink"
-                      : "bg-p-paper border-p-line text-p-ink hover:border-p-ink-3"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
-                  </svg>
-                  {t("registry.filters.bbox")}
-                </button>
+                {/* Only rendered once the export distinguishes official copies
+                    from mirrors. A control with one option filters nothing. */}
+                {availableKinds.length > 1 && (
+                  <div className="relative">
+                    <select
+                      value={kindFilter}
+                      onChange={(e) => setKindFilter(e.target.value as typeof kindFilter)}
+                      className="appearance-none bg-p-paper border border-p-line ps-3 pe-8 py-2.5 text-body text-p-ink focus:outline-none focus:border-p-primary transition-colors cursor-pointer"
+                      aria-label={t("registry.filters.kind")}
+                    >
+                      <option value="all">{t("registry.filters.allKinds")}</option>
+                      {availableKinds.map((kind) => (
+                        <option key={kind} value={kind}>
+                          {t(`registry.kind.${kind}`)}
+                        </option>
+                      ))}
+                    </select>
+                    <svg className="absolute end-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-p-ink-3 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                )}
 
                 {/* Cards | Map view toggle */}
-                <div className="flex items-stretch border border-p-line rounded-[var(--p-r-md)] overflow-hidden self-start sm:self-auto sm:ms-auto">
+                <div className="flex items-stretch border border-p-line overflow-hidden self-start sm:self-auto sm:ms-auto">
                   {(["cards", "map"] as const).map((view, i) => {
                     const isActive = registryView === view;
                     return (
@@ -417,26 +395,6 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                 </div>
               </div>
 
-              {showBboxFilter && (
-                <div className="flex flex-wrap items-center gap-3 p-4 bg-p-paper border border-p-line rounded-[var(--p-r-md)]">
-                  <span className="text-micro text-p-ink-3 font-mono w-full sm:w-auto">{t("registry.filters.bboxLabel")}</span>
-                  <div className="flex flex-wrap gap-2">
-                    {(["west", "south", "east", "north"] as const).map((dir) => (
-                      <div key={dir} className="flex items-center gap-1">
-                        <label className="text-micro text-p-ink-3 uppercase w-6">{t(`registry.compass.${dir}`)}</label>
-                        <input
-                          type="number"
-                          step="any"
-                          value={bboxFilter[dir]}
-                          onChange={(e) => setBboxFilter((prev) => ({ ...prev, [dir]: e.target.value }))}
-                          placeholder={dir === "west" || dir === "east" ? t("registry.filters.lonPlaceholder") : t("registry.filters.latPlaceholder")}
-                          className="w-20 px-2 py-1.5 text-micro bg-p-bg border border-p-line rounded-[var(--p-r-sm)] text-p-ink placeholder:text-p-ink-3 focus:outline-none focus:border-p-primary"
-                        />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
 
               {hasActiveFilters && (
                 <button
@@ -471,11 +429,25 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
               </div>
             )}
 
-            {/* Annotation row: same anatomy as a figure caption */}
-            <div className="flex justify-between gap-3 pt-2 border-t border-p-line-soft font-mono text-eyebrow text-p-ink-3">
-              <span className="text-p-primary">{t("registry.caption")}</span>
+            {/* Annotation row: same anatomy as a figure caption. It names the
+                source of the data and how fresh it is, which nothing else on
+                the page says. */}
+            <div className="flex flex-wrap justify-between gap-x-3 gap-y-1 mt-3 pt-2 border-t border-p-line-soft font-mono text-eyebrow text-p-ink-3">
+              <a
+                href="https://github.com/portolan-sdi/portolan-registry"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-p-primary hover:underline"
+              >
+                <Ltr>portolan-sdi/portolan-registry</Ltr> ↗
+              </a>
               <span>
-                {t("registry.captionNote", { count: filteredCatalogs.length })}
+                {filteredCatalogs.length < catalogs.length &&
+                  `${t("registry.captionFiltered", {
+                    shown: String(filteredCatalogs.length),
+                    total: String(catalogs.length),
+                  })} · `}
+                {crawledAt && t("registry.captionCrawled", { date: crawledAt })}
               </span>
             </div>
 

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -1,39 +1,65 @@
 "use client";
 
-import { useState } from "react";
-import { useTranslations } from "next-intl";
+import { Fragment, useState, type ReactNode } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { Card, Tag, DirArrow, Ltr } from "../ui";
 import type { Catalog } from "@/lib/catalogs";
-import { getBrowserUrl, getLicenseSummary, getValidationTier } from "@/lib/catalogs";
+import {
+  formatBytes,
+  formatCount,
+  formatDate,
+  getBrowserUrl,
+  getLicenseSummary,
+  getValidationTier,
+} from "@/lib/catalogs";
+import { CopyUrlButton } from "./copy-url-button";
 
 interface CatalogCardProps {
   catalog: Catalog;
 }
 
-function getRegionFromBbox(bbox: [number, number, number, number] | null) {
-  if (!bbox) return null;
-  const [west, south, east, north] = bbox;
-  const centerLat = (south + north) / 2;
-  const centerLon = (west + east) / 2;
-
-  return {
-    lat: Math.abs(centerLat).toFixed(0),
-    latDir: centerLat >= 0 ? ("north" as const) : ("south" as const),
-    lon: Math.abs(centerLon).toFixed(0),
-    lonDir: centerLon >= 0 ? ("east" as const) : ("west" as const),
-  };
-}
-
-export function CatalogCard({ catalog }: CatalogCardProps) {
-  const t = useTranslations("registry");
-  const [logoBroken, setLogoBroken] = useState(false);
-  const tier = getValidationTier(catalog.validation);
-  const region = getRegionFromBbox(catalog.bbox);
-  const license = getLicenseSummary(catalog.licenses);
-  const logo = logoBroken ? null : catalog.logo;
+// Dot-separated run of facts. Anything the crawl did not report is dropped
+// rather than printed as "unknown", so cards stay ragged and every line on a
+// card is a fact about that catalog.
+function MetaRow({ children }: { children: ReactNode[] }) {
+  const items = children.filter(Boolean);
+  if (items.length === 0) return null;
 
   return (
-    <Card className="flex flex-col gap-3">
+    <p className="flex flex-wrap items-center gap-x-1.5 text-micro text-p-ink-3 font-mono">
+      {items.map((item, i) => (
+        <Fragment key={i}>
+          {i > 0 && <span aria-hidden="true">·</span>}
+          <span>{item}</span>
+        </Fragment>
+      ))}
+    </p>
+  );
+}
+
+/** Card contents without the surrounding chrome, so the map panel can reuse it. */
+export function CatalogCardBody({ catalog }: CatalogCardProps) {
+  const t = useTranslations("registry");
+  const locale = useLocale();
+  const [logoBroken, setLogoBroken] = useState(false);
+
+  const logo = logoBroken ? null : catalog.logo;
+  const tier = getValidationTier(catalog.validation);
+  const license = getLicenseSummary(catalog.licenses);
+  const size = formatBytes(catalog.total_size_bytes, locale);
+  const updated = formatDate(catalog.updated, locale);
+
+  // A catalog holds either vector features or raster items, rarely both worth
+  // naming. Lead with whichever the crawl actually counted.
+  const contents =
+    catalog.feature_count > 0
+      ? t("card.features", { count: formatCount(catalog.feature_count, locale) })
+      : catalog.item_count > 0
+        ? t("card.items", { count: formatCount(catalog.item_count, locale) })
+        : null;
+
+  return (
+    <>
       {logo && (
         // Logos come from whatever host the catalog lives on, so there is no
         // finite allowlist to give next/image's remotePatterns. A plain <img>
@@ -51,54 +77,62 @@ export function CatalogCard({ catalog }: CatalogCardProps) {
 
       <div className="flex justify-between items-start gap-2">
         <h3 className="text-card-title font-semibold line-clamp-2">{catalog.title}</h3>
-        <Tag
-          tone={tier === "full" ? "accent" : tier === "basic" ? "primary" : "default"}
-          className="shrink-0"
+        {/* Badge the exceptions only. A tag that reads the same on every card
+            is chrome, not information. */}
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          {catalog.kind && <Tag tone="primary">{t(`kind.${catalog.kind}`)}</Tag>}
+          {catalog.stale_since && <Tag tone="accent">{t("status.stale")}</Tag>}
+          {tier === "unvalidated" && <Tag>{t("validation.unvalidated")}</Tag>}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        {/* What the catalog holds. */}
+        <MetaRow>
+          {catalog.collection_count === 1
+            ? t("card.collection")
+            : t("card.collections", {
+                count: formatCount(catalog.collection_count, locale),
+              })}
+          {contents}
+          {size}
+        </MetaRow>
+
+        {/* How it is published, and how current it is. */}
+        <MetaRow>
+          {catalog.spec_version && (
+            <Ltr>{t("card.specVersion", { version: catalog.spec_version })}</Ltr>
+          )}
+          {updated && t("card.updated", { date: updated })}
+          {license &&
+            (license.kind === "single" ? (
+              <Ltr>{license.id}</Ltr>
+            ) : (
+              t("card.licenses", { count: String(license.count) })
+            ))}
+          {!catalog.bbox && t("card.noLocation")}
+        </MetaRow>
+      </div>
+
+      <div className="mt-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2 pt-1">
+        <CopyUrlButton url={catalog.url} />
+        <a
+          href={getBrowserUrl(catalog.url)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-small text-p-primary hover:underline"
         >
-          {t(`validation.${tier}`)}
-        </Tag>
+          {t("card.viewCatalog")} <DirArrow />
+        </a>
       </div>
+    </>
+  );
+}
 
-      <div className="flex flex-wrap gap-2 text-micro text-p-ink-3 font-mono">
-        <span>{t("card.collections", { count: catalog.collection_count })}</span>
-        {catalog.stac_version && (
-          <>
-            <span>·</span>
-            <span>STAC {catalog.stac_version}</span>
-          </>
-        )}
-        {license && (
-          <>
-            <span>·</span>
-            <span>
-              {license.kind === "single" ? (
-                <Ltr>{license.id}</Ltr>
-              ) : (
-                t("card.licenses", { count: license.count })
-              )}
-            </span>
-          </>
-        )}
-        {region && (
-          <>
-            <span>·</span>
-            <span>
-              {region.lat}
-              {t(`compass.${region.latDir}`)}, {region.lon}
-              {t(`compass.${region.lonDir}`)}
-            </span>
-          </>
-        )}
-      </div>
-
-      <a
-        href={getBrowserUrl(catalog.url)}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mt-auto text-small text-p-primary hover:underline"
-      >
-        {t("card.viewCatalog")} <DirArrow />
-      </a>
+export function CatalogCard({ catalog }: CatalogCardProps) {
+  return (
+    <Card className="flex flex-col gap-3">
+      <CatalogCardBody catalog={catalog} />
     </Card>
   );
 }

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useState, type ReactNode } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { Card, Tag, DirArrow, Ltr } from "../ui";
+import { Tag, DirArrow, Ltr } from "../ui";
 import type { Catalog } from "@/lib/catalogs";
 import {
   formatBytes,
@@ -14,13 +14,13 @@ import {
 } from "@/lib/catalogs";
 import { CopyUrlButton } from "./copy-url-button";
 
-interface CatalogCardProps {
+interface CatalogProps {
   catalog: Catalog;
 }
 
 // Dot-separated run of facts. Anything the crawl did not report is dropped
-// rather than printed as "unknown", so cards stay ragged and every line on a
-// card is a fact about that catalog.
+// rather than printed as "unknown", so every line reads as a fact about that
+// catalog.
 function MetaRow({ children }: { children: ReactNode[] }) {
   const items = children.filter(Boolean);
   if (items.length === 0) return null;
@@ -37,26 +37,12 @@ function MetaRow({ children }: { children: ReactNode[] }) {
   );
 }
 
-/** Card contents without the surrounding chrome, so the map panel can reuse it. */
-export function CatalogCardBody({ catalog }: CatalogCardProps) {
+/** Logo, title, and any exception badge. Shared by the card front and the map panel. */
+export function CatalogHeader({ catalog }: CatalogProps) {
   const t = useTranslations("registry");
-  const locale = useLocale();
   const [logoBroken, setLogoBroken] = useState(false);
-
   const logo = logoBroken ? null : catalog.logo;
   const tier = getValidationTier(catalog.validation);
-  const license = getLicenseSummary(catalog.licenses);
-  const size = formatBytes(catalog.total_size_bytes, locale);
-  const updated = formatDate(catalog.updated, locale);
-
-  // A catalog holds either vector features or raster items, rarely both worth
-  // naming. Lead with whichever the crawl actually counted.
-  const contents =
-    catalog.feature_count > 0
-      ? t("card.features", { count: formatCount(catalog.feature_count, locale) })
-      : catalog.item_count > 0
-        ? t("card.items", { count: formatCount(catalog.item_count, locale) })
-        : null;
 
   return (
     <>
@@ -74,9 +60,8 @@ export function CatalogCardBody({ catalog }: CatalogCardProps) {
           className="h-8 w-auto max-w-[160px] self-start object-contain"
         />
       )}
-
-      <div className="flex justify-between items-start gap-2">
-        <h3 className="text-card-title font-semibold line-clamp-2">{catalog.title}</h3>
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-card-title font-semibold line-clamp-3">{catalog.title}</h3>
         {/* Badge the exceptions only. A tag that reads the same on every card
             is chrome, not information. */}
         <div className="flex shrink-0 flex-col items-end gap-1">
@@ -85,54 +70,157 @@ export function CatalogCardBody({ catalog }: CatalogCardProps) {
           {tier === "unvalidated" && <Tag>{t("validation.unvalidated")}</Tag>}
         </div>
       </div>
-
-      <div className="space-y-1">
-        {/* What the catalog holds. */}
-        <MetaRow>
-          {catalog.collection_count === 1
-            ? t("card.collection")
-            : t("card.collections", {
-                count: formatCount(catalog.collection_count, locale),
-              })}
-          {contents}
-          {size}
-        </MetaRow>
-
-        {/* How it is published, and how current it is. */}
-        <MetaRow>
-          {catalog.spec_version && (
-            <Ltr>{t("card.specVersion", { version: catalog.spec_version })}</Ltr>
-          )}
-          {updated && t("card.updated", { date: updated })}
-          {license &&
-            (license.kind === "single" ? (
-              <Ltr>{license.id}</Ltr>
-            ) : (
-              t("card.licenses", { count: String(license.count) })
-            ))}
-          {!catalog.bbox && t("card.noLocation")}
-        </MetaRow>
-      </div>
-
-      <div className="mt-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2 pt-1">
-        <CopyUrlButton url={catalog.url} />
-        <a
-          href={getBrowserUrl(catalog.url)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-small text-p-primary hover:underline"
-        >
-          {t("card.viewCatalog")} <DirArrow />
-        </a>
-      </div>
     </>
   );
 }
 
-export function CatalogCard({ catalog }: CatalogCardProps) {
+/** Everything the crawl measured. Shared by the card back and the map panel. */
+export function CatalogFacts({ catalog }: CatalogProps) {
+  const t = useTranslations("registry");
+  const locale = useLocale();
+
+  const license = getLicenseSummary(catalog.licenses);
+  const size = formatBytes(catalog.total_size_bytes, locale);
+  const updated = formatDate(catalog.updated, locale);
+
+  // A catalog holds either vector features or raster items, rarely both worth
+  // naming. Lead with whichever the crawl actually counted.
+  const contents =
+    catalog.feature_count > 0
+      ? t("card.features", { count: formatCount(catalog.feature_count, locale) })
+      : catalog.item_count > 0
+        ? t("card.items", { count: formatCount(catalog.item_count, locale) })
+        : null;
+
   return (
-    <Card className="flex flex-col gap-3">
-      <CatalogCardBody catalog={catalog} />
-    </Card>
+    <>
+      <MetaRow>
+        {collectionLabel(catalog, t, locale)}
+        {contents}
+        {size}
+      </MetaRow>
+      <MetaRow>
+        {catalog.spec_version && (
+          <Ltr>{t("card.specVersion", { version: catalog.spec_version })}</Ltr>
+        )}
+        {updated && t("card.updated", { date: updated })}
+        {license &&
+          (license.kind === "single" ? (
+            <Ltr>{license.id}</Ltr>
+          ) : (
+            t("card.licenses", { count: String(license.count) })
+          ))}
+        {!catalog.bbox && t("card.noLocation")}
+      </MetaRow>
+    </>
+  );
+}
+
+/**
+ * Copy the address, or open the catalog in the browser. `tabbable` is false on
+ * a card face that is turned away, so its controls leave the tab order while
+ * they are invisible.
+ */
+export function CatalogActions({
+  catalog,
+  tabbable = true,
+}: CatalogProps & { tabbable?: boolean }) {
+  const t = useTranslations("registry");
+  const tabIndex = tabbable ? 0 : -1;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+      <CopyUrlButton url={catalog.url} tabIndex={tabIndex} />
+      <a
+        href={getBrowserUrl(catalog.url)}
+        target="_blank"
+        rel="noopener noreferrer"
+        tabIndex={tabIndex}
+        className="text-small text-p-primary hover:underline"
+      >
+        {t("card.viewCatalog")} <DirArrow />
+      </a>
+    </div>
+  );
+}
+
+function collectionLabel(
+  catalog: Catalog,
+  t: ReturnType<typeof useTranslations<"registry">>,
+  locale: string
+) {
+  return catalog.collection_count === 1
+    ? t("card.collection")
+    : t("card.collections", { count: formatCount(catalog.collection_count, locale) });
+}
+
+// The front carries identity and the primary action, the back carries the
+// measurements. Both faces stay in the accessibility tree, so a screen reader
+// reads the whole card without turning it. The hidden face's controls leave
+// the tab order, which keeps invisible buttons unreachable.
+//
+// Height is fixed rather than derived from content. The faces are absolutely
+// positioned, so the card needs a height, and a uniform grid keeps the page
+// from reflowing as cards turn.
+export function CatalogCard({ catalog }: CatalogProps) {
+  const t = useTranslations("registry");
+  const locale = useLocale();
+  const [flipped, setFlipped] = useState(false);
+  const updated = formatDate(catalog.updated, locale);
+
+  return (
+    <div className="tk-flip tk-flip--manual">
+      <div className="tk-flip__inner relative h-[260px] w-full" data-flipped={flipped}>
+        <div className="tk-flip__face absolute inset-0 flex flex-col gap-3 border border-p-line bg-p-paper p-5">
+          <CatalogHeader catalog={catalog} />
+          <MetaRow>
+            {collectionLabel(catalog, t, locale)}
+            {updated && t("card.updated", { date: updated })}
+          </MetaRow>
+
+          <div className="mt-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <a
+              href={getBrowserUrl(catalog.url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              tabIndex={flipped ? -1 : 0}
+              className="text-small text-p-primary hover:underline"
+            >
+              {t("card.viewCatalog")} <DirArrow />
+            </a>
+            <button
+              type="button"
+              aria-expanded={flipped}
+              tabIndex={flipped ? -1 : 0}
+              onClick={() => setFlipped(true)}
+              className="font-mono text-micro text-p-ink-3 transition-colors hover:text-p-ink cursor-pointer"
+            >
+              {t("card.showDetails")}
+            </button>
+          </div>
+        </div>
+
+        <div className="tk-flip__back tk-flip__face absolute inset-0 flex flex-col gap-2 border border-p-line bg-p-bg-soft p-5">
+          <CatalogFacts catalog={catalog} />
+
+          <div className="mt-auto">
+            <CatalogActions catalog={catalog} tabbable={flipped} />
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setFlipped(false)}
+            tabIndex={flipped ? 0 : -1}
+            className="absolute top-3 end-3 text-p-ink-3 hover:text-p-ink transition-colors cursor-pointer"
+            aria-label={t("card.hideDetails")}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -168,8 +168,28 @@ export function CatalogCard({ catalog }: CatalogProps) {
   const [flipped, setFlipped] = useState(false);
   const updated = formatDate(catalog.updated, locale);
 
+  // The same link on both faces. Only the face you can see is tabbable.
+  const viewCatalog = (tabIndex: number) => (
+    <a
+      href={getBrowserUrl(catalog.url)}
+      target="_blank"
+      rel="noopener noreferrer"
+      tabIndex={tabIndex}
+      className="text-small text-p-primary hover:underline"
+    >
+      {t("card.viewCatalog")} <DirArrow />
+    </a>
+  );
+
   return (
-    <div className="tk-flip tk-flip--manual">
+    <div
+      className="tk-flip tk-flip--manual"
+      onMouseEnter={() => setFlipped(true)}
+      onMouseLeave={() => setFlipped(false)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setFlipped(false);
+      }}
+    >
       <div className="tk-flip__inner relative h-[260px] w-full" data-flipped={flipped}>
         <div className="tk-flip__face absolute inset-0 flex flex-col gap-3 border border-p-line bg-p-paper p-5">
           <CatalogHeader catalog={catalog} />
@@ -178,40 +198,48 @@ export function CatalogCard({ catalog }: CatalogProps) {
             {updated && t("card.updated", { date: updated })}
           </MetaRow>
 
-          <div className="mt-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-            <a
-              href={getBrowserUrl(catalog.url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              tabIndex={flipped ? -1 : 0}
-              className="text-small text-p-primary hover:underline"
-            >
-              {t("card.viewCatalog")} <DirArrow />
-            </a>
-            <button
-              type="button"
-              aria-expanded={flipped}
-              tabIndex={flipped ? -1 : 0}
-              onClick={() => setFlipped(true)}
-              className="font-mono text-micro text-p-ink-3 transition-colors hover:text-p-ink cursor-pointer"
-            >
-              {t("card.showDetails")}
-            </button>
-          </div>
+          {/* Anchored to the same corner as the back's copy of this link. The
+              card turns as the pointer arrives, and the target does not move. */}
+          <div className="mt-auto flex justify-end">{viewCatalog(flipped ? -1 : 0)}</div>
+
+          {/* Turns the card where there is no pointer to hover with. Sits under
+              the action row so it never swallows a tap meant for the link. */}
+          <button
+            type="button"
+            aria-expanded={flipped}
+            tabIndex={-1}
+            aria-hidden="true"
+            onClick={() => setFlipped(true)}
+            className="absolute inset-x-0 top-0 bottom-14 cursor-pointer"
+          />
+
+          {/* Keyboard-only route to the back. Invisible until focused, so
+              pointer users never see a control they do not need. */}
+          <button
+            type="button"
+            aria-expanded={flipped}
+            onFocus={() => setFlipped(true)}
+            onClick={() => setFlipped(true)}
+            className="sr-only focus:not-sr-only focus:absolute focus:bottom-5 focus:start-5 focus:z-10 focus:border focus:border-p-line focus:bg-p-paper focus:px-2 focus:py-1 focus:font-mono focus:text-micro"
+          >
+            {t("card.showDetails")}
+          </button>
         </div>
 
         <div className="tk-flip__back tk-flip__face absolute inset-0 flex flex-col gap-2 border border-p-line bg-p-bg-soft p-5">
           <CatalogFacts catalog={catalog} />
 
-          <div className="mt-auto">
-            <CatalogActions catalog={catalog} tabbable={flipped} />
+          <div className="mt-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <CopyUrlButton url={catalog.url} tabIndex={flipped ? 0 : -1} />
+            {viewCatalog(flipped ? 0 : -1)}
           </div>
 
+          {/* Only devices without hover need a way back. A pointer just leaves. */}
           <button
             type="button"
             onClick={() => setFlipped(false)}
             tabIndex={flipped ? 0 : -1}
-            className="absolute top-3 end-3 text-p-ink-3 hover:text-p-ink transition-colors cursor-pointer"
+            className="absolute top-3 end-3 hidden text-p-ink-3 transition-colors hover:text-p-ink cursor-pointer [@media(hover:none)]:block"
             aria-label={t("card.hideDetails")}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -2,7 +2,7 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import {
   Map as MapGL,
@@ -20,9 +20,9 @@ import type {
   ExpressionSpecification,
 } from "maplibre-gl";
 import type { Catalog } from "@/lib/catalogs";
-import { getBrowserUrl, getValidationTier } from "@/lib/catalogs";
+import { getCoverageTier } from "@/lib/catalogs";
 import { MapGeocoder } from "./map-geocoder";
-import { Tag, DirArrow } from "../ui";
+import { CatalogCardBody } from "./catalog-card";
 import type { GeocodeSuggestion } from "@/hooks/use-geocode";
 
 const CARTO_STYLE =
@@ -75,13 +75,13 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [hover, setHover] = useState<{ lng: number; lat: number; title: string } | null>(null);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
-  const [infoOpen, setInfoOpen] = useState(false);
 
-  const { points, polys, bounds, byId, unlocatedCount } = useMemo(() => {
+  const { points, polys, bounds, byId, globalCatalogs, unlocated } = useMemo(() => {
     const pointFeatures: GeoJSON.Feature<GeoJSON.Point>[] = [];
     const polyFeatures: GeoJSON.Feature<GeoJSON.Polygon>[] = [];
     const byId = new Map<string, Catalog>();
-    let unlocatedCount = 0;
+    const globalCatalogs: Catalog[] = [];
+    const unlocated: Catalog[] = [];
     let w = 180;
     let s = 90;
     let e = -180;
@@ -89,7 +89,7 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
 
     for (const catalog of catalogs) {
       if (!catalog.bbox) {
-        unlocatedCount++;
+        unlocated.push(catalog);
         continue;
       }
       const [west, south, east, north] = catalog.bbox;
@@ -108,10 +108,19 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
         east >= -180 &&
         east <= 180;
       if (!validBbox) {
-        unlocatedCount++;
+        unlocated.push(catalog);
         continue;
       }
       byId.set(catalog.id, catalog);
+
+      // A catalog claiming most of the globe covers every located one beneath
+      // it and drags the initial fit out to the whole world. It leaves the map
+      // and is listed underneath instead, where it stays selectable.
+      if (getCoverageTier(catalog.bbox) === "global") {
+        globalCatalogs.push(catalog);
+        continue;
+      }
+
       const crossesAntimeridian = west > east;
       const widthDeg = crossesAntimeridian ? east + 360 - west : east - west;
       const heightDeg = north - south;
@@ -122,17 +131,20 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
       const rectZoom = eligibleRect
         ? rectZoomFor(Math.max(widthDeg, heightDeg))
         : NEVER_RECT_ZOOM;
+      // Continent-scale boxes keep their outline but drop the fill, so a
+      // country-scale catalog inside one stays readable through it.
+      const tier = getCoverageTier(catalog.bbox) ?? "local";
 
       pointFeatures.push({
         type: "Feature",
-        properties: { catalogId: catalog.id, rectZoom },
+        properties: { catalogId: catalog.id, rectZoom, tier },
         geometry: { type: "Point", coordinates: centroid },
       });
 
       if (eligibleRect) {
         polyFeatures.push({
           type: "Feature",
-          properties: { catalogId: catalog.id, rectZoom },
+          properties: { catalogId: catalog.id, rectZoom, tier },
           geometry: {
             type: "Polygon",
             coordinates: [
@@ -167,7 +179,7 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
     const bounds: Bounds | null =
       pointFeatures.length > 0 ? [[w, s], [e, n]] : null;
 
-    return { points, polys, bounds, byId, unlocatedCount };
+    return { points, polys, bounds, byId, globalCatalogs, unlocated };
   }, [catalogs]);
 
   // Selection resolves through the current catalog set, so a filtered-out
@@ -261,22 +273,46 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
   };
   const fillPaint: FillLayerSpecification["paint"] = {
     "fill-color": colors.primary,
-    "fill-opacity": ["case", selectedExpr, 0.25, 0.15],
+    "fill-opacity": [
+      "case",
+      ["==", ["get", "tier"], "large"],
+      ["case", selectedExpr, 0.12, 0.05],
+      selectedExpr,
+      0.25,
+      0.15,
+    ],
   };
   const linePaint: LineLayerSpecification["paint"] = {
     "line-color": ["case", selectedExpr, colors.accent, colors.primary],
     "line-width": ["case", selectedExpr, 3, 2],
   };
 
+  const dashedLinePaint: LineLayerSpecification["paint"] = {
+    "line-color": ["case", selectedExpr, colors.accent, colors.primary],
+    "line-width": ["case", selectedExpr, 2.5, 1.5],
+    "line-dasharray": [3, 2],
+    "line-opacity": 0.8,
+  };
+
   const dotFilter: ExpressionSpecification = [">", ["get", "rectZoom"], zoom];
   const rectFilter: ExpressionSpecification = ["<=", ["get", "rectZoom"], zoom];
+  const localRectFilter: ExpressionSpecification = [
+    "all",
+    rectFilter,
+    ["==", ["get", "tier"], "local"],
+  ];
+  const largeRectFilter: ExpressionSpecification = [
+    "all",
+    rectFilter,
+    ["==", ["get", "tier"], "large"],
+  ];
 
 
   return (
     <>
       <div
         dir="ltr"
-        className="relative h-[520px] md:h-[600px] rounded-[var(--p-r-lg)] border border-p-line overflow-hidden"
+        className="relative h-[520px] md:h-[600px] border border-p-line overflow-hidden"
         role="application"
         aria-label={t("map.searchLabel")}
       >
@@ -297,8 +333,17 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
           style={{ width: "100%", height: "100%" }}
         >
           <Source id="catalog-polys" type="geojson" data={polys}>
+            {/* One fill across both tiers so a continent-scale box stays a
+                click target, at an opacity that keeps it from washing out the
+                smaller catalogs drawn inside it. */}
             <Layer id="catalog-bbox-fill" type="fill" filter={rectFilter} paint={fillPaint} />
-            <Layer id="catalog-bbox-line" type="line" filter={rectFilter} paint={linePaint} />
+            <Layer id="catalog-bbox-line" type="line" filter={localRectFilter} paint={linePaint} />
+            <Layer
+              id="catalog-bbox-large"
+              type="line"
+              filter={largeRectFilter}
+              paint={dashedLinePaint}
+            />
           </Source>
           <Source id="catalog-points" type="geojson" data={points}>
             <Layer id="catalog-dots" type="circle" filter={dotFilter} paint={dotPaint} />
@@ -324,7 +369,7 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
         </div>
 
         {/* Zoom + reset stack (top-right) */}
-        <div className="absolute top-3 end-3 z-10 flex flex-col rounded-[var(--p-r-md)] overflow-hidden border border-p-line shadow-[var(--p-shadow-md)]">
+        <div className="absolute top-3 end-3 z-10 flex flex-col overflow-hidden border border-p-line">
           <button
             type="button"
             onClick={() => mapRef.current?.zoomIn()}
@@ -364,108 +409,131 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
 
         {/* Detail panel (bottom-left) */}
         {selected && (
-          <div className="absolute bottom-3 start-3 z-10 w-[340px] max-w-[calc(100%-1.5rem)] bg-p-paper border border-p-line rounded-[var(--p-r-md)] p-4 shadow-[var(--p-shadow-lg)]">
-            {selected.logo && (
-              // Same reasoning as catalog-card: catalog-hosted logos have no
-              // finite host allowlist for next/image's remotePatterns.
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={selected.logo.href}
-                alt={selected.logo.title ?? selected.title}
-                loading="lazy"
-                className="mb-2 h-6 w-auto max-w-[140px] object-contain"
-              />
-            )}
-            <div className="flex items-start justify-between gap-2">
-              <h3 className="text-card-title font-semibold line-clamp-2">
-                {selected.title}
-              </h3>
-              <button
-                type="button"
-                onClick={() => setSelectedId(null)}
-                aria-label={t("map.closeDetails")}
-                className="shrink-0 text-p-ink-3 hover:text-p-ink transition-colors"
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <line x1="18" y1="6" x2="6" y2="18" />
-                  <line x1="6" y1="6" x2="18" y2="18" />
-                </svg>
-              </button>
-            </div>
-            <div className="mt-2">
-              {(() => {
-                const tier = getValidationTier(selected.validation);
-                return (
-                  <Tag
-                    tone={tier === "full" ? "accent" : tier === "basic" ? "primary" : "default"}
-                  >
-                    {t(`validation.${tier}`)}
-                  </Tag>
-                );
-              })()}
-            </div>
-            <p className="mt-3 text-micro text-p-ink-3 font-mono">
-              {t("card.collections", { count: selected.collection_count })}
-              {selected.stac_version && ` · STAC ${selected.stac_version}`}
-            </p>
-            <a
-              href={getBrowserUrl(selected.url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-block text-small text-p-primary hover:underline"
+          <div className="absolute bottom-3 start-3 z-10 flex w-[340px] max-w-[calc(100%-1.5rem)] flex-col gap-3 bg-p-paper border border-p-line p-4 pe-9">
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              aria-label={t("map.closeDetails")}
+              className="absolute top-3 end-3 z-10 text-p-ink-3 hover:text-p-ink transition-colors"
             >
-              {t("card.viewCatalog")} <DirArrow />
-            </a>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+            {/* Same component the grid renders, so the two views cannot drift. */}
+            <CatalogCardBody catalog={selected} />
           </div>
         )}
 
-        {/* Attribution + info (bottom-right) */}
-        <div className="absolute bottom-3 end-3 z-10 flex items-center gap-2">
-          {infoOpen && (
-            <div className="w-[260px] max-w-[calc(100vw-2rem)] bg-p-paper border border-p-line rounded-[var(--p-r-md)] p-3 shadow-[var(--p-shadow-md)] text-micro text-p-ink-2 leading-relaxed">
-              {t("map.infoBody")}
-            </div>
-          )}
-          <div className="flex items-center gap-2 bg-p-paper/90 backdrop-blur-sm border border-p-line rounded-[var(--p-r-md)] px-2.5 py-1">
-            <span className="text-micro text-p-ink-3 font-mono">
-              {"© "}
-              <a
-                href="https://carto.com/attributions"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-p-ink-2 underline underline-offset-2"
-              >
-                CARTO
-              </a>
-              {" © "}
-              <a
-                href="https://www.openstreetmap.org/copyright"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-p-ink-2 underline underline-offset-2"
-              >
-                OpenStreetMap
-              </a>
-              {" contributors"}
-            </span>
-            <button
-              type="button"
-              onClick={() => setInfoOpen((v) => !v)}
-              aria-label={t("map.info")}
-              aria-expanded={infoOpen}
-              className="shrink-0 flex items-center justify-center w-5 h-5 border border-p-line text-p-ink-3 hover:text-p-ink hover:border-p-ink-3 transition-colors text-micro font-mono"
+        {/* Attribution (bottom-right). Solid, per the flat-surface rule. */}
+        <div className="absolute bottom-3 end-3 z-10 bg-p-paper border border-p-line px-2.5 py-1">
+          <span className="text-micro text-p-ink-3 font-mono">
+            {"© "}
+            <a
+              href="https://carto.com/attributions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-p-ink-2 underline underline-offset-2"
             >
-              i
-            </button>
-          </div>
+              CARTO
+            </a>
+            {" · © "}
+            <a
+              href="https://www.openstreetmap.org/copyright"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-p-ink-2 underline underline-offset-2"
+            >
+              OSM
+            </a>
+            {" · "}
+            <a
+              href="https://nominatim.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-p-ink-2 underline underline-offset-2"
+            >
+              Nominatim
+            </a>
+          </span>
         </div>
       </div>
 
-      {unlocatedCount > 0 && (
-        <p className="mt-3 text-micro text-p-ink-3 font-mono">
-          {t("map.noLocation", { count: unlocatedCount })}
-        </p>
-      )}
+      {/* Legend and the catalogs the map cannot place. Always visible: it is
+          shorter than the popover it replaced and does not need opening. */}
+      <div className="mt-3 flex flex-col gap-3 text-micro font-mono text-p-ink-3">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5" dir="ltr">
+          <LegendKey label={t("map.legend.dot")}>
+            <circle cx="7" cy="7" r="4.5" fill="var(--p-primary)" />
+          </LegendKey>
+          <LegendKey label={t("map.legend.area")}>
+            <rect
+              x="1.5"
+              y="2.5"
+              width="11"
+              height="9"
+              fill="var(--p-primary)"
+              fillOpacity={0.2}
+              stroke="var(--p-primary)"
+              strokeWidth="1.5"
+            />
+          </LegendKey>
+          <LegendKey label={t("map.legend.wide")}>
+            <rect
+              x="1.5"
+              y="2.5"
+              width="11"
+              height="9"
+              fill="none"
+              stroke="var(--p-primary)"
+              strokeWidth="1.5"
+              strokeDasharray="3 2"
+            />
+          </LegendKey>
+        </div>
+
+        {(globalCatalogs.length > 0 || unlocated.length > 0) && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+            <span className="text-p-ink-2">
+              {globalCatalogs.length > 0
+                ? t("map.worldwide")
+                : t("map.noLocation", { count: String(unlocated.length) })}
+            </span>
+            {globalCatalogs.map((catalog) => (
+              <button
+                key={catalog.id}
+                type="button"
+                onClick={() =>
+                  setSelectedId((current) => (current === catalog.id ? null : catalog.id))
+                }
+                aria-pressed={selectedId === catalog.id}
+                className={`max-w-[22ch] truncate border px-2 py-0.5 transition-colors cursor-pointer ${
+                  selectedId === catalog.id
+                    ? "border-p-primary text-p-primary"
+                    : "border-p-line-soft hover:border-p-ink-3 hover:text-p-ink"
+                }`}
+              >
+                {catalog.title}
+              </button>
+            ))}
+            {globalCatalogs.length > 0 && unlocated.length > 0 && (
+              <span>· {t("map.noLocation", { count: String(unlocated.length) })}</span>
+            )}
+          </div>
+        )}
+      </div>
     </>
+  );
+}
+
+function LegendKey({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" className="shrink-0">
+        {children}
+      </svg>
+      {label}
+    </span>
   );
 }

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -2,7 +2,7 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   Map as MapGL,
@@ -22,7 +22,7 @@ import type {
 import type { Catalog } from "@/lib/catalogs";
 import { getCoverageTier } from "@/lib/catalogs";
 import { MapGeocoder } from "./map-geocoder";
-import { CatalogCardBody } from "./catalog-card";
+import { CatalogHeader, CatalogFacts, CatalogActions } from "./catalog-card";
 import type { GeocodeSuggestion } from "@/hooks/use-geocode";
 
 const CARTO_STYLE =
@@ -75,12 +75,12 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [hover, setHover] = useState<{ lng: number; lat: number; title: string } | null>(null);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [infoOpen, setInfoOpen] = useState(false);
 
-  const { points, polys, bounds, byId, globalCatalogs, unlocated } = useMemo(() => {
+  const { points, polys, bounds, byId, unlocated } = useMemo(() => {
     const pointFeatures: GeoJSON.Feature<GeoJSON.Point>[] = [];
     const polyFeatures: GeoJSON.Feature<GeoJSON.Polygon>[] = [];
     const byId = new Map<string, Catalog>();
-    const globalCatalogs: Catalog[] = [];
     const unlocated: Catalog[] = [];
     let w = 180;
     let s = 90;
@@ -112,14 +112,6 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
         continue;
       }
       byId.set(catalog.id, catalog);
-
-      // A catalog claiming most of the globe covers every located one beneath
-      // it and drags the initial fit out to the whole world. It leaves the map
-      // and is listed underneath instead, where it stays selectable.
-      if (getCoverageTier(catalog.bbox) === "global") {
-        globalCatalogs.push(catalog);
-        continue;
-      }
 
       const crossesAntimeridian = west > east;
       const widthDeg = crossesAntimeridian ? east + 360 - west : east - west;
@@ -179,7 +171,7 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
     const bounds: Bounds | null =
       pointFeatures.length > 0 ? [[w, s], [e, n]] : null;
 
-    return { points, polys, bounds, byId, globalCatalogs, unlocated };
+    return { points, polys, bounds, byId, unlocated };
   }, [catalogs]);
 
   // Selection resolves through the current catalog set, so a filtered-out
@@ -421,119 +413,49 @@ export default function CatalogMap({ catalogs }: CatalogMapProps) {
                 <line x1="6" y1="6" x2="18" y2="18" />
               </svg>
             </button>
-            {/* Same component the grid renders, so the two views cannot drift. */}
-            <CatalogCardBody catalog={selected} />
+            {/* Same pieces the grid card is built from, so the two cannot drift. */}
+            <CatalogHeader catalog={selected} />
+            <CatalogFacts catalog={selected} />
+            <CatalogActions catalog={selected} />
           </div>
         )}
 
-        {/* Attribution (bottom-right). Solid, per the flat-surface rule. */}
-        <div className="absolute bottom-3 end-3 z-10 bg-p-paper border border-p-line px-2.5 py-1">
-          <span className="text-micro text-p-ink-3 font-mono">
-            {"© "}
-            <a
-              href="https://carto.com/attributions"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-p-ink-2 underline underline-offset-2"
-            >
-              CARTO
-            </a>
-            {" · © "}
-            <a
-              href="https://www.openstreetmap.org/copyright"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-p-ink-2 underline underline-offset-2"
-            >
-              OSM
-            </a>
-            {" · "}
-            <a
-              href="https://nominatim.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-p-ink-2 underline underline-offset-2"
-            >
-              Nominatim
-            </a>
-          </span>
+        {/* Credits, closed by default. Attribution has to be reachable, and it
+            does not have to sit across the bottom of the map to be. */}
+        <div className="absolute bottom-3 end-3 z-10 flex items-end gap-2">
+          {infoOpen && (
+            <div className="w-[240px] max-w-[calc(100vw-2rem)] border border-p-line bg-p-paper p-3 text-micro font-mono text-p-ink-2 leading-relaxed">
+              {"© "}
+              <a href="https://carto.com/attributions" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-p-ink">
+                CARTO
+              </a>
+              {" · © "}
+              <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-p-ink">
+                OpenStreetMap
+              </a>
+              {" · "}
+              <a href="https://nominatim.org/" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-p-ink">
+                Nominatim
+              </a>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() => setInfoOpen((v) => !v)}
+            aria-label={t("map.info")}
+            aria-expanded={infoOpen}
+            className="flex h-6 w-6 shrink-0 items-center justify-center border border-p-line bg-p-paper font-mono text-micro text-p-ink-3 transition-colors hover:text-p-ink"
+          >
+            i
+          </button>
         </div>
       </div>
 
-      {/* Legend and the catalogs the map cannot place. Always visible: it is
-          shorter than the popover it replaced and does not need opening. */}
-      <div className="mt-3 flex flex-col gap-3 text-micro font-mono text-p-ink-3">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5" dir="ltr">
-          <LegendKey label={t("map.legend.dot")}>
-            <circle cx="7" cy="7" r="4.5" fill="var(--p-primary)" />
-          </LegendKey>
-          <LegendKey label={t("map.legend.area")}>
-            <rect
-              x="1.5"
-              y="2.5"
-              width="11"
-              height="9"
-              fill="var(--p-primary)"
-              fillOpacity={0.2}
-              stroke="var(--p-primary)"
-              strokeWidth="1.5"
-            />
-          </LegendKey>
-          <LegendKey label={t("map.legend.wide")}>
-            <rect
-              x="1.5"
-              y="2.5"
-              width="11"
-              height="9"
-              fill="none"
-              stroke="var(--p-primary)"
-              strokeWidth="1.5"
-              strokeDasharray="3 2"
-            />
-          </LegendKey>
-        </div>
-
-        {(globalCatalogs.length > 0 || unlocated.length > 0) && (
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
-            <span className="text-p-ink-2">
-              {globalCatalogs.length > 0
-                ? t("map.worldwide")
-                : t("map.noLocation", { count: String(unlocated.length) })}
-            </span>
-            {globalCatalogs.map((catalog) => (
-              <button
-                key={catalog.id}
-                type="button"
-                onClick={() =>
-                  setSelectedId((current) => (current === catalog.id ? null : catalog.id))
-                }
-                aria-pressed={selectedId === catalog.id}
-                className={`max-w-[22ch] truncate border px-2 py-0.5 transition-colors cursor-pointer ${
-                  selectedId === catalog.id
-                    ? "border-p-primary text-p-primary"
-                    : "border-p-line-soft hover:border-p-ink-3 hover:text-p-ink"
-                }`}
-              >
-                {catalog.title}
-              </button>
-            ))}
-            {globalCatalogs.length > 0 && unlocated.length > 0 && (
-              <span>· {t("map.noLocation", { count: String(unlocated.length) })}</span>
-            )}
-          </div>
-        )}
-      </div>
+      {unlocated.length > 0 && (
+        <p className="mt-3 text-micro font-mono text-p-ink-3">
+          {t("map.noLocation", { count: String(unlocated.length) })}
+        </p>
+      )}
     </>
-  );
-}
-
-function LegendKey({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <span className="flex items-center gap-1.5">
-      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true" className="shrink-0">
-        {children}
-      </svg>
-      {label}
-    </span>
   );
 }

--- a/src/components/registry/copy-url-button.tsx
+++ b/src/components/registry/copy-url-button.tsx
@@ -6,13 +6,15 @@ import { useTranslations } from "next-intl";
 interface CopyUrlButtonProps {
   url: string;
   className?: string;
+  /** -1 while the card face holding this button is turned away. */
+  tabIndex?: number;
 }
 
 const RESET_MS = 2000;
 
 // Copies a catalog.json address so it can be pasted into a client. The label
 // stays in place and swaps text, so the row does not reflow on click.
-export function CopyUrlButton({ url, className }: CopyUrlButtonProps) {
+export function CopyUrlButton({ url, className, tabIndex }: CopyUrlButtonProps) {
   const t = useTranslations("registry.card");
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -40,6 +42,7 @@ export function CopyUrlButton({ url, className }: CopyUrlButtonProps) {
     <button
       type="button"
       onClick={handleCopy}
+      tabIndex={tabIndex}
       title={url}
       className={`inline-flex items-center gap-1.5 text-micro font-mono text-p-ink-3 hover:text-p-ink transition-colors cursor-pointer ${className ?? ""}`}
     >

--- a/src/components/registry/copy-url-button.tsx
+++ b/src/components/registry/copy-url-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface CopyUrlButtonProps {
+  url: string;
+  className?: string;
+}
+
+const RESET_MS = 2000;
+
+// Copies a catalog.json address so it can be pasted into a client. The label
+// stays in place and swaps text, so the row does not reflow on click.
+export function CopyUrlButton({ url, className }: CopyUrlButtonProps) {
+  const t = useTranslations("registry.card");
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Clipboard access is refused on insecure origins and in some embedded
+      // browsers. Selecting the address by hand still works, so say nothing.
+      return;
+    }
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), RESET_MS);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={url}
+      className={`inline-flex items-center gap-1.5 text-micro font-mono text-p-ink-3 hover:text-p-ink transition-colors cursor-pointer ${className ?? ""}`}
+    >
+      {copied ? (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="11" height="11" />
+          <path d="M5 15V5a2 2 0 0 1 2-2h8" />
+        </svg>
+      )}
+      <span aria-live="polite">{copied ? t("copied") : t("copyUrl")}</span>
+    </button>
+  );
+}

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -14,18 +14,35 @@ export interface CatalogLogo {
   title?: string;
 }
 
+// Whether the publisher runs the authoritative copy or re-hosts someone
+// else's. The registry does not export this yet, so it is null for every
+// catalog today and the UI hides the control that filters on it. See
+// https://github.com/portolan-sdi/portolan-registry/issues (kind field).
+export type CatalogKind = "official" | "mirror";
+
 export interface Catalog {
   id: string;
   url: string;
   title: string;
-  stac_version: string | null;
+  kind: CatalogKind | null;
+  /** Portolan spec version the catalog declares. Null for plain STAC. */
+  spec_version: string | null;
   bbox: [number, number, number, number] | null;
   logo: CatalogLogo | null;
   collection_count: number;
   feature_count: number;
+  item_count: number;
+  asset_count: number;
+  /** Sum over the catalog's assets. Null when the crawl could not total it. */
+  total_size_bytes: number | null;
   // SPDX id -> how many collections declare it.
   licenses: Record<string, number>;
+  /** When the data last changed, as the catalog itself reports it. */
+  updated: string | null;
+  /** When the registry last read the catalog. Same for every entry in a run. */
   last_crawled: string | null;
+  /** Set once the registry stops being able to read the catalog. */
+  stale_since: string | null;
   validation: CatalogValidation;
 }
 
@@ -46,12 +63,18 @@ interface ChildLink {
   title?: string;
   bbox?: [number, number, number, number] | null;
   "portolan_registry:id": string;
-  "portolan_registry:stac_version"?: string | null;
+  "portolan_registry:kind"?: string | null;
+  "portolan_registry:spec_version"?: string | null;
   "portolan_registry:logo"?: CatalogLogo | null;
   "portolan_registry:collection_count"?: number | null;
   "portolan_registry:feature_count"?: number | null;
+  "portolan_registry:item_count"?: number | null;
+  "portolan_registry:asset_count"?: number | null;
+  "portolan_registry:total_size_bytes"?: number | null;
   "portolan_registry:licenses"?: Record<string, number> | null;
+  "portolan_registry:updated"?: string | null;
   "portolan_registry:last_crawled"?: string | null;
+  "portolan_registry:stale_since"?: string | null;
   "portolan_registry:stac_valid"?: boolean | null;
   "portolan_registry:has_versions_json"?: boolean | null;
   "portolan_registry:has_portolan_dir"?: boolean | null;
@@ -78,6 +101,10 @@ function isBbox(value: unknown): value is [number, number, number, number] {
   );
 }
 
+function toKind(value: unknown): CatalogKind | null {
+  return value === "official" || value === "mirror" ? value : null;
+}
+
 function toCatalog(link: ChildLink): Catalog {
   const logo = link["portolan_registry:logo"];
 
@@ -85,13 +112,19 @@ function toCatalog(link: ChildLink): Catalog {
     id: link["portolan_registry:id"],
     url: link.href,
     title: link.title ?? link["portolan_registry:id"],
-    stac_version: link["portolan_registry:stac_version"] ?? null,
+    kind: toKind(link["portolan_registry:kind"]),
+    spec_version: link["portolan_registry:spec_version"] ?? null,
     bbox: isBbox(link.bbox) ? link.bbox : null,
     logo: logo && logo.href ? logo : null,
     collection_count: link["portolan_registry:collection_count"] ?? 0,
     feature_count: link["portolan_registry:feature_count"] ?? 0,
+    item_count: link["portolan_registry:item_count"] ?? 0,
+    asset_count: link["portolan_registry:asset_count"] ?? 0,
+    total_size_bytes: link["portolan_registry:total_size_bytes"] ?? null,
     licenses: link["portolan_registry:licenses"] ?? {},
+    updated: link["portolan_registry:updated"] ?? null,
     last_crawled: link["portolan_registry:last_crawled"] ?? null,
+    stale_since: link["portolan_registry:stale_since"] ?? null,
     validation: {
       stac_valid: link["portolan_registry:stac_valid"] ?? false,
       has_versions_json: link["portolan_registry:has_versions_json"] ?? false,
@@ -144,6 +177,92 @@ export function getValidationTier(validation: CatalogValidation): "unvalidated" 
     return "basic";
   }
   return "unvalidated";
+}
+
+// How much of the world a catalog claims. Three catalogs in the registry today
+// declare a bbox covering 75% or more of the globe, so drawing every bbox the
+// same way buries the located ones under a full-canvas wash. The map spends
+// each tier differently: `local` draws filled, `large` draws as an outline, and
+// `global` leaves the map for a labelled group beneath it.
+export type CoverageTier = "local" | "large" | "global";
+
+const GLOBAL_AREA_FRACTION = 0.5;
+const LARGE_AREA_FRACTION = 0.15;
+const LARGE_LON_FRACTION = 0.8;
+
+/** Degree spans of a bbox, treating west > east as an antimeridian crossing. */
+export function getBboxSpans(bbox: [number, number, number, number]) {
+  const [west, south, east, north] = bbox;
+  const lonSpan = west > east ? east + 360 - west : east - west;
+  const latSpan = north - south;
+  return { lonSpan, latSpan, lonFraction: lonSpan / 360, latFraction: latSpan / 180 };
+}
+
+export function getCoverageTier(
+  bbox: [number, number, number, number] | null
+): CoverageTier | null {
+  if (!bbox) return null;
+  const { lonFraction, latFraction } = getBboxSpans(bbox);
+  const areaFraction = lonFraction * latFraction;
+
+  if (areaFraction >= GLOBAL_AREA_FRACTION) return "global";
+  // A band spanning every longitude covers little area but still crosses the
+  // whole map, so it earns the quieter treatment on longitude alone.
+  if (areaFraction >= LARGE_AREA_FRACTION || lonFraction >= LARGE_LON_FRACTION) {
+    return "large";
+  }
+  return "local";
+}
+
+// Object stores report sizes in decimal units, so 1 MB is 10^6 bytes here.
+const BYTE_UNITS = ["B", "kB", "MB", "GB", "TB", "PB"] as const;
+
+/** Latin digits in every locale, per the translation contract. */
+function numberLocale(locale: string): string {
+  return locale === "ar" ? "ar-u-nu-latn" : locale;
+}
+
+export function formatBytes(bytes: number | null, locale: string): string | null {
+  if (bytes === null || !Number.isFinite(bytes) || bytes < 0) return null;
+
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1000 && unit < BYTE_UNITS.length - 1) {
+    value /= 1000;
+    unit++;
+  }
+
+  // Whole bytes read oddly with a decimal, and so does a four-digit gigabyte.
+  const digits = unit === 0 || value >= 100 ? 0 : 1;
+  const formatted = new Intl.NumberFormat(numberLocale(locale), {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }).format(value);
+
+  return `${formatted} ${BYTE_UNITS[unit]}`;
+}
+
+export function formatCount(value: number, locale: string): string {
+  return new Intl.NumberFormat(numberLocale(locale), {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+// Fixed to UTC so the server and the client agree on the day. Without it a
+// timestamp near midnight formats differently in each and React reports a
+// hydration mismatch.
+export function formatDate(iso: string | null, locale: string): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return new Intl.DateTimeFormat(numberLocale(locale), {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
 }
 
 // The export reports licenses as an SPDX id -> collection count map. One id is


### PR DESCRIPTION
## What this changes

Catalog cards turn over. The front carries the logo, title, collection count,
update date, and the link to the catalog. The back carries what the crawl
measured, plus a button that copies the `catalog.json` address. World-scale
catalogs get a Global datasets block under the map instead of a chip row. The
grid pages at six, the map loses its legend, and attribution folds back behind
a closed `i` button.

## Why

Closes #50. Four strings carried one fact between them. Three of the eight
registered catalogs claim 75% or more of the globe, and their stacked fills
buried the other five. Counts went through ICU plurals, which render
Arabic-Indic digits on `/ar/` and break the translation contract in `AGENTS.md`.

## Verification

Coverage tiers and card strings, from the shipped `src/lib/catalogs.ts` run
against the live export at
`https://raw.githubusercontent.com/portolan-sdi/portolan-registry/refs/heads/main/exports/catalogs.json`:

```shell
$ node verify.mjs
global catalog-1781203130384     192 collections · 1.9M features
global global-data               6 collections · 191 items · 15.9 MB · portolan 0.1.0 · Jul 28, 2026
global jrc-glofas                16 collections · 4.3K items
local  pergamino-ide             178 collections · 706.7K features
local  portolan-nl               34 collections · 95M features · portolan 0.1.0 · Aug 1, 2026
local  st-louis-open-data-mirro  51 collections · 6.6M features · 1.9 GB · portolan 0.1.0 · Aug 5, 2026
local  trimet                    8 collections · 15.2K features · 34.2 MB · portolan 0.1.0 · Aug 2, 2026
local  venezuela-earthquake-202  2 collections · 57 items

Arabic digits stay Latin: 95 مليون | 1.9 GB | 5 أغسطس 2026
```

The three `global` rows are the ones that fill the Global datasets block. Sizes
and dates appear only where the crawl reported them.

Section header and the prerendered Global datasets block:

```shell
$ pnpm exec tsc --noEmit && pnpm exec eslint src && pnpm build
✓ Compiled successfully in 2.7s
  Finished TypeScript in 2.9s

$ python3 extract.py .next/server/app/en.html
Browse 8 catalogs
portolan-registry ↗ · Last checked: Aug 12, 2026
Cards / Map
Global datasets
Capas de Referencia del Instituto Geográfico Nacional de Argentina
192 collections
View catalog → / Details
```
