### PR TITLE
fix: read the validation fields the registry exports

### DIFF
--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -1,8 +1,17 @@
+// What the registry checks about a catalog during a crawl.
+//
+// `stac_valid` comes from the crawl itself. The other two report the Markdown
+// documents that Portolan v0.1.2 requires at a catalog root. PORTO-CORE-061
+// asks for AGENTS.md under `rel: "agents"`. PORTO-CORE-062 asks for README.md
+// under `rel: "describedby"`. Both are MUST.
+//
+// These two replaced three earlier flags in August 2026. The old flags read a
+// spec draft that portolan-spec deleted before v0.1.0, so every catalog
+// reported the same values. See portolan-registry#89.
 export interface CatalogValidation {
   stac_valid: boolean;
-  has_versions_json: boolean;
-  has_portolan_dir: boolean;
-  has_llms_txt?: boolean;
+  has_agents_md: boolean;
+  has_readme: boolean;
 }
 
 // Read off the catalog's own `rel: "icon"` link. The registry resolves the
@@ -76,9 +85,8 @@ interface ChildLink {
   "portolan_registry:last_crawled"?: string | null;
   "portolan_registry:stale_since"?: string | null;
   "portolan_registry:stac_valid"?: boolean | null;
-  "portolan_registry:has_versions_json"?: boolean | null;
-  "portolan_registry:has_portolan_dir"?: boolean | null;
-  "portolan_registry:has_llms_txt"?: boolean | null;
+  "portolan_registry:has_agents_md"?: boolean | null;
+  "portolan_registry:has_readme"?: boolean | null;
 }
 
 interface RegistryExport {
@@ -127,9 +135,8 @@ function toCatalog(link: ChildLink): Catalog {
     stale_since: link["portolan_registry:stale_since"] ?? null,
     validation: {
       stac_valid: link["portolan_registry:stac_valid"] ?? false,
-      has_versions_json: link["portolan_registry:has_versions_json"] ?? false,
-      has_portolan_dir: link["portolan_registry:has_portolan_dir"] ?? false,
-      has_llms_txt: link["portolan_registry:has_llms_txt"] ?? false,
+      has_agents_md: link["portolan_registry:has_agents_md"] ?? false,
+      has_readme: link["portolan_registry:has_readme"] ?? false,
     },
   };
 }
@@ -167,10 +174,14 @@ export function getBrowserUrl(catalogUrl: string): string {
   return `${BROWSER_BASE}${withoutScheme}`;
 }
 
+// The card badges "unvalidated" only, so no tier reaches a pixel today. The
+// registry also sets `stac_valid` to true for every catalog, which makes
+// "unvalidated" unreachable. Both gaps need a decision. See
+// portolan-registry#89.
 export function getValidationTier(validation: CatalogValidation): "unvalidated" | "basic" | "full" {
-  const { stac_valid, has_versions_json, has_portolan_dir } = validation;
+  const { stac_valid, has_agents_md, has_readme } = validation;
 
-  if (stac_valid && has_versions_json && has_portolan_dir) {
+  if (stac_valid && has_agents_md && has_readme) {
     return "full";
   }
   if (stac_valid) {


### PR DESCRIPTION
## What changed

`src/lib/catalogs.ts` reads the two validation fields the registry publishes
now, in place of three it drops.

- `CatalogValidation` names `has_agents_md` and `has_readme`.
- `ChildLink` names `portolan_registry:has_agents_md` and `portolan_registry:has_readme`.
- `toCatalog` maps both new fields.
- `getValidationTier` returns "full" when a catalog publishes both documents.

`has_versions_json`, `has_portolan_dir`, and `has_llms_txt` go away. No source
file names them now. `stac_valid` does not change, and no component changes.

Two comments record where the fields come from and what the tier cannot do yet.

## Why

Resolves #60. It follows portolan-registry#89 and portolan-registry#90.

The registry removed the three old flags because no released Portolan version
defines them. They read a spec draft that portolan-spec deleted before v0.1.0.
Every registered catalog reported the same three values, so the block carried
no signal.

The site read two of those flags in the "full" branch of `getValidationTier`.
The normalizer reads each field with a `?? false` fallback. That branch would
therefore never run again once the fields go away.

The two new fields report the Markdown documents that Portolan v0.1.2 requires
at a catalog root. PORTO-CORE-061 asks for AGENTS.md under `rel: "agents"`.
PORTO-CORE-062 asks for README.md under `rel: "describedby"`. Both are MUST.
Ten of the twelve registered catalogs publish both. Two publish neither.

## Verification

The tier reacts to all three export shapes. The script transpiles
`src/lib/catalogs.ts` and runs `toCatalog` and `getValidationTier` over one
child link per shape.

```shell
$ node ./tier-check.mjs
export on main today (old fields only)
  validation: {"stac_valid":true,"has_agents_md":false,"has_readme":false}
  tier: basic
export after #90, catalog with both documents
  validation: {"stac_valid":true,"has_agents_md":true,"has_readme":true}
  tier: full
export after #90, catalog with neither (jrc-glofas)
  validation: {"stac_valid":true,"has_agents_md":false,"has_readme":false}
  tier: basic
```

The middle case is the point of the change. The "full" tier is reachable for
the first time.

The first case shows the deploy order does not matter. The export on main still
carries the old fields. The site then computes "basic" for every catalog, which
is what it computes today.

The build passes against that live export.

```shell
$ ./node_modules/.bin/next build
✓ Generating static pages using 10 workers (13/13) in 1376ms
Route (app)              Revalidate  Expire
├ ● /[locale]                    1h      1y
│ ├ /en                          1h      1y
│ ├ /es                          1h      1y
│ └ /ar                          1h      1y
```

The build reads this file:
https://raw.githubusercontent.com/portolan-sdi/portolan-registry/main/exports/catalogs.json

The typecheck and the lint pass.

```shell
$ ./node_modules/.bin/tsc --noEmit
$ ./node_modules/.bin/eslint src/lib/catalogs.ts src/components/registry/catalog-card.tsx
```

Both commands print nothing and exit zero.

## Notes for the reviewer

Merge portolan-registry#90 first. The site works before that merge and after
it, so the order is a preference and not a requirement. Until the registry
export regenerates, every catalog stays on "basic".

This change does not put the tier on screen. The `CatalogHeader` component
badges "unvalidated" only. Its comment says why. "Badge the exceptions only. A
tag that reads the same on every card is chrome, not information." The registry
also sets `stac_valid` to true for every catalog, so "unvalidated" cannot
happen.

The exception is now a catalog that misses a MUST-level document. Two catalogs
match. A badge for them is a product decision about other people's catalogs.
This pull request leaves that decision to a human. Issue #60 records the
question.
