### PR TITLE
feat(home): add community section and footer

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -31,6 +31,19 @@
   "involved": {
     "ariaLabel": "المستخدمون والداعمون"
   },
+  "getInvolved": {
+    "title": "شارك",
+    "priority": "أسهل طريقة للبدء الآن هي <publish>نشر بياناتك في كتالوج Portolan</publish> وإخبارنا بالنتيجة. تفيدنا دائما ملاحظاتك عما يعمل وما لا يعمل وكيف يمكن تحسين Portolan، خاصة إذا اختلف تنفيذك عن الكتالوجات الحالية.",
+    "contributions": "نرحب أيضا بالمساهمات في <github>معيار Portolan وأدواته</github> من خلال تقارير الأخطاء وطلبات الميزات وPRs. نرحب بشكل خاص بـ PRs. راجع <issues>المسائل المفتوحة</issues> للبدء.",
+    "community": "Portolan مشروع مجتمعي مفتوح المصدر ونرحب بالمستخدمين والمساهمين الجدد. انضم إلى قناة <slack><m>#portolan</m> على Slack</slack> وتابع <group>مجموعة Portolan على Google</group> لمعرفة تفاصيل اجتماعاتنا الأسبوعية."
+  },
+  "footer": {
+    "contentLicense": "محتوى الموقع مرخّص بموجب <cc><m>CC BY 4.0</m></cc>.",
+    "sourceLicense": "مصدر الموقع مرخّص بموجب <apache><m>Apache-2.0</m></apache>.",
+    "contact": "التواصل",
+    "googleGroup": "مجموعة Google",
+    "slack": "Slack <m>#portolan</m>"
+  },
   "why": {
     "cards": {
       "open": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,19 @@
   "involved": {
     "ariaLabel": "Users and supporters"
   },
+  "getInvolved": {
+    "title": "Get involved",
+    "priority": "The simplest way to get started right now is to <publish>publish your data as a Portolan catalog</publish> and let us know how it goes. Feedback on what works, what doesn't, and how Portolan can be improved is always helpful, especially when your implementation differs from existing catalogs.",
+    "contributions": "We also welcome contributions to the <github>Portolan spec and tooling</github> in the form of bug reports, feature requests, and PRs (and especially PRs). Check out our <issues>open issues</issues> to get started.",
+    "community": "Portolan is an open-source community project—we welcome new users and contributors. Join the <slack><m>#portolan</m> channel on Slack</slack> and follow the <group>Portolan Google Group</group> for details on our weekly meetings."
+  },
+  "footer": {
+    "contentLicense": "Site content is licensed under <cc><m>CC BY 4.0</m></cc>.",
+    "sourceLicense": "Website source is licensed under <apache><m>Apache-2.0</m></apache>.",
+    "contact": "Contact",
+    "googleGroup": "Google Group",
+    "slack": "Slack <m>#portolan</m>"
+  },
   "why": {
     "cards": {
       "open": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,6 +31,19 @@
   "involved": {
     "ariaLabel": "Usuarios y colaboradores"
   },
+  "getInvolved": {
+    "title": "Participa",
+    "priority": "La forma más sencilla de empezar ahora es <publish>publicar tus datos como un catálogo de Portolan</publish> y contarnos cómo fue. Siempre ayudan los comentarios sobre lo que funciona, lo que no funciona y cómo podemos mejorar Portolan, sobre todo si tu implementación difiere de los catálogos existentes.",
+    "contributions": "También aceptamos contribuciones al <github>estándar y las herramientas de Portolan</github> mediante informes de errores, solicitudes de funciones y PRs. Nos interesan en especial los PRs. Consulta nuestros <issues>asuntos abiertos</issues> para empezar.",
+    "community": "Portolan es un proyecto comunitario de código abierto. Damos la bienvenida a nuevos usuarios y colaboradores. Únete al canal <slack><m>#portolan</m> en Slack</slack> y sigue el <group>Grupo de Google de Portolan</group> para conocer los detalles de nuestras reuniones semanales."
+  },
+  "footer": {
+    "contentLicense": "El contenido del sitio tiene una licencia <cc><m>CC BY 4.0</m></cc>.",
+    "sourceLicense": "El código fuente del sitio tiene una licencia <apache><m>Apache-2.0</m></apache>.",
+    "contact": "Contacto",
+    "googleGroup": "Grupo de Google",
+    "slack": "Slack <m>#portolan</m>"
+  },
   "why": {
     "cards": {
       "open": {

--- a/src/components/get-involved-section.tsx
+++ b/src/components/get-involved-section.tsx
@@ -1,0 +1,82 @@
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { COMMUNITY_LINKS } from "@/lib/site";
+import { Ltr, monoChunk } from "./ui";
+
+const proseLink =
+  "text-p-primary underline underline-offset-2 transition-colors hover:text-p-ink";
+
+const external = { target: "_blank", rel: "noopener noreferrer" } as const;
+
+export function GetInvolvedSection() {
+  const t = useTranslations("getInvolved");
+
+  return (
+    <section
+      id="involved"
+      className="border-y border-p-line px-[var(--p-pad-section-x)] py-[var(--p-pad-section-y)]"
+    >
+      <div className="mx-auto max-w-[1240px]">
+        <h2 className="text-section font-extrabold tracking-[-0.03em] leading-[1.05]">
+          {t("title")}
+        </h2>
+        <div className="mt-6 space-y-5 text-lead leading-relaxed text-p-ink-2">
+          <p>
+            {t.rich("community", {
+              group: (chunks) => (
+                <a
+                  href={COMMUNITY_LINKS.googleGroup}
+                  className={proseLink}
+                  {...external}
+                >
+                  {chunks}
+                </a>
+              ),
+              slack: (chunks) => (
+                <a
+                  href={COMMUNITY_LINKS.slack}
+                  className={proseLink}
+                  {...external}
+                >
+                  {chunks}
+                </a>
+              ),
+              m: (chunks) => <Ltr>{monoChunk(chunks)}</Ltr>,
+            })}
+          </p>
+          <p>
+            {t.rich("priority", {
+              publish: (chunks) => (
+                <Link href="/#how" className={proseLink}>
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </p>
+          <p>
+            {t.rich("contributions", {
+              github: (chunks) => (
+                <a
+                  href={COMMUNITY_LINKS.github}
+                  className={proseLink}
+                  {...external}
+                >
+                  {chunks}
+                </a>
+              ),
+              issues: (chunks) => (
+                <a
+                  href={COMMUNITY_LINKS.openIssues}
+                  className={proseLink}
+                  {...external}
+                >
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -9,6 +9,7 @@ import { SiteShell } from "./site-rail";
 import { ResourcesSection } from "./resources-section";
 import { EcosystemSection } from "./ecosystem-section";
 import { InvolvedSection } from "./involved-section";
+import { GetInvolvedSection } from "./get-involved-section";
 import { WhoForSection } from "./who-for-section";
 import { PipelineFigure } from "./pipeline-figure";
 import { Btn, DirArrow, Ltr, SectionHead, monoChunk } from "./ui";
@@ -415,6 +416,9 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
 
       {/* Talks & demos */}
       <ResourcesSection />
+
+      {/* Community contribution paths */}
+      <GetInvolvedSection />
 
       {/* Registry — the living proof, deliberately the last section */}
       {catalogs.length > 0 && (

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,64 @@
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { COMMUNITY_LINKS, LICENSE_LINKS } from "@/lib/site";
+import { PortolanLogo } from "./portolan-logo";
+import { Ltr, monoChunk } from "./ui";
+
+const licenseLink =
+  "underline underline-offset-2";
+
+export function SiteFooter() {
+  const t = useTranslations();
+
+  return (
+    <footer className="px-[var(--p-pad-section-x)] pb-6 pt-10">
+      <div className="mx-auto max-w-[1240px]">
+        <div className="flex flex-col items-start gap-6 sm:flex-row sm:gap-10">
+          <Link href="/" aria-label={t("nav.homeAria")} className="w-fit">
+            <PortolanLogo size={30} />
+          </Link>
+
+          <div className="text-start text-small">
+            <p className="mb-2 font-mono text-eyebrow text-p-ink-3">
+              {t("footer.contact")}
+            </p>
+            <div className="flex flex-col items-start gap-1">
+              <a
+                href={COMMUNITY_LINKS.googleGroup}
+                className="text-p-ink-2 transition-colors hover:text-p-primary"
+              >
+                {t("footer.googleGroup")}
+              </a>
+              <a
+                href={COMMUNITY_LINKS.slack}
+                className="text-p-ink-2 transition-colors hover:text-p-primary"
+              >
+                <Ltr>{t.rich("footer.slack", { m: monoChunk })}</Ltr>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-10 text-center text-small text-p-ink-3">
+          {t.rich("footer.contentLicense", {
+            m: monoChunk,
+            cc: (chunks) => (
+              <a href={LICENSE_LINKS.content} className={licenseLink}>
+                <Ltr>{chunks}</Ltr>
+              </a>
+            ),
+          })}{" "}
+          ·{" "}
+          {t.rich("footer.sourceLicense", {
+            m: monoChunk,
+            apache: (chunks) => (
+              <a href={LICENSE_LINKS.source} className={licenseLink}>
+                <Ltr>{chunks}</Ltr>
+              </a>
+            ),
+          })}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/site-rail.tsx
+++ b/src/components/site-rail.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { PortolanLogo } from "./portolan-logo";
 import { LocaleSwitcher } from "./locale-switcher";
+import { SiteFooter } from "./site-footer";
 import { DirArrow } from "./ui";
 
 // Primary navigation lives in a left rail (replaces the old minimal header +
@@ -23,6 +24,7 @@ const SECTIONS = [
   { id: "how", label: "howItWorks.eyebrow" },
   { id: "ecosystem", label: "ecosystem.eyebrow" },
   { id: "resources", label: "resources.title" },
+  { id: "involved", label: "getInvolved.title" },
   { id: "registry", label: "nav.registry" },
 ] as const;
 
@@ -207,7 +209,10 @@ export function SiteShell({ children }: { children: React.ReactNode }) {
         </button>
       </div>
 
-      <main className="site-main">{children}</main>
+      <div className="site-main">
+        <main>{children}</main>
+        <SiteFooter />
+      </div>
     </div>
   );
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,6 +8,23 @@ import { routing } from "@/i18n/routing";
 export const SITE_ORIGIN = "https://www.portolan-sdi.org";
 
 /**
+ * Canonical community and license destinations used by the homepage close.
+ * Keep these aligned with portolan-ops/copy/urls.md.
+ */
+export const COMMUNITY_LINKS = {
+  github: "https://github.com/portolan-sdi",
+  googleGroup: "https://groups.google.com/g/portolan",
+  openIssues: "https://github.com/orgs/portolan-sdi/projects/1/views/2",
+  slack: "https://cloudnativegeo.slack.com/archives/C0A1JBH9529",
+} as const;
+
+export const LICENSE_LINKS = {
+  content: "https://creativecommons.org/licenses/by/4.0/",
+  source:
+    "https://github.com/portolan-sdi/portolan-sdi.org/blob/main/LICENSE",
+} as const;
+
+/**
  * Path for a locale under `localePrefix: "as-needed"`: the default locale is
  * served unprefixed, every other locale carries its prefix.
  */


### PR DESCRIPTION
## What changed

This change adds a full-width Get involved section to the homepage.

The section links to Slack, the Google Group, the Portolan projects, and open issues.

This change adds a footer with the Portolan logo and left-aligned contact links.

A centered grey line states the site content license and the website source license.

English, Spanish, and Arabic provide the same content and link structure.

Resolves #64.

## Why

The homepage gives visitors no direct path to the Portolan community.

The site also needs visible license terms and stable contact links.

Canonical constants keep these destinations consistent across the site.

## Verification

The checks read the localized homepage copy in `messages/en.json`, `messages/es.json`, and `messages/ar.json`.

The homepage target is https://www.portolan-sdi.org/.

```text
$ pnpm exec eslint src/components/get-involved-section.tsx src/components/site-footer.tsx
(no output)

$ pnpm build
✓ Compiled successfully in 3.0s
✓ Finished TypeScript in 3.2s
✓ Generating static pages using 10 workers (13/13) in 581ms

$ git diff --check
(no output)
```