### PR TITLE
feat(footer): add development, community, and resources columns

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -10,7 +10,6 @@
     "homeAria": "الصفحة الرئيسية لـ Portolan",
     "languageAria": "تغيير اللغة",
     "index": "الفهرس",
-    "external": "روابط خارجية",
     "who": "لمن هو",
     "collapse": "طي الفهرس",
     "expand": "الفهرس",
@@ -35,9 +34,14 @@
   "footer": {
     "contentLicense": "محتوى الموقع مرخّص بموجب <cc><m>CC BY 4.0</m></cc>.",
     "sourceLicense": "مصدر الموقع مرخّص بموجب <apache><m>Apache-2.0</m></apache>.",
-    "contact": "التواصل",
     "googleGroup": "مجموعة Google",
-    "slack": "Slack <m>#portolan</m>"
+    "slack": "Slack",
+    "community": "المجتمع",
+    "development": "التطوير",
+    "githubOrg": "منظمة GitHub",
+    "issues": "المشكلات المفتوحة",
+    "resources": "الموارد",
+    "repositories": "المستودعات"
   },
   "why": {
     "cards": {

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -6,7 +6,6 @@
   "nav": {
     "registry": "السجل",
     "why": "لماذا Portolan",
-    "docs": "التوثيق",
     "homeAria": "الصفحة الرئيسية لـ Portolan",
     "languageAria": "تغيير اللغة",
     "index": "الفهرس",
@@ -38,10 +37,9 @@
     "slack": "Slack",
     "community": "المجتمع",
     "development": "التطوير",
-    "githubOrg": "منظمة GitHub",
-    "issues": "المشكلات المفتوحة",
     "resources": "الموارد",
-    "repositories": "المستودعات"
+    "roadmap": "خارطة الطريق",
+    "github": "GitHub"
   },
   "why": {
     "cards": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,6 @@
     "homeAria": "Portolan home",
     "languageAria": "Change language",
     "index": "Index",
-    "external": "External",
     "who": "Who it's for",
     "collapse": "Collapse the index",
     "expand": "Index",
@@ -35,9 +34,14 @@
   "footer": {
     "contentLicense": "Site content is licensed under <cc><m>CC BY 4.0</m></cc>.",
     "sourceLicense": "Website source is licensed under <apache><m>Apache-2.0</m></apache>.",
-    "contact": "Contact",
     "googleGroup": "Google Group",
-    "slack": "Slack <m>#portolan</m>"
+    "slack": "Slack",
+    "community": "Community",
+    "development": "Development",
+    "githubOrg": "GitHub org",
+    "issues": "Open issues",
+    "resources": "Resources",
+    "repositories": "Repositories"
   },
   "why": {
     "cards": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,7 +6,6 @@
   "nav": {
     "registry": "Registry",
     "why": "Why Portolan",
-    "docs": "Docs",
     "homeAria": "Portolan home",
     "languageAria": "Change language",
     "index": "Index",
@@ -38,10 +37,9 @@
     "slack": "Slack",
     "community": "Community",
     "development": "Development",
-    "githubOrg": "GitHub org",
-    "issues": "Open issues",
     "resources": "Resources",
-    "repositories": "Repositories"
+    "roadmap": "Roadmap",
+    "github": "GitHub"
   },
   "why": {
     "cards": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,7 +6,6 @@
   "nav": {
     "registry": "Registro",
     "why": "Por qué Portolan",
-    "docs": "Docs",
     "homeAria": "Inicio de Portolan",
     "languageAria": "Cambiar idioma",
     "index": "Índice",
@@ -38,10 +37,9 @@
     "slack": "Slack",
     "community": "Comunidad",
     "development": "Desarrollo",
-    "githubOrg": "Organización en GitHub",
-    "issues": "Incidencias abiertas",
     "resources": "Recursos",
-    "repositories": "Repositorios"
+    "roadmap": "Hoja de ruta",
+    "github": "GitHub"
   },
   "why": {
     "cards": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -10,7 +10,6 @@
     "homeAria": "Inicio de Portolan",
     "languageAria": "Cambiar idioma",
     "index": "Índice",
-    "external": "Externo",
     "who": "Para quién es",
     "collapse": "Contraer el índice",
     "expand": "Índice",
@@ -35,9 +34,14 @@
   "footer": {
     "contentLicense": "El contenido del sitio tiene una licencia <cc><m>CC BY 4.0</m></cc>.",
     "sourceLicense": "El código fuente del sitio tiene una licencia <apache><m>Apache-2.0</m></apache>.",
-    "contact": "Contacto",
     "googleGroup": "Grupo de Google",
-    "slack": "Slack <m>#portolan</m>"
+    "slack": "Slack",
+    "community": "Comunidad",
+    "development": "Desarrollo",
+    "githubOrg": "Organización en GitHub",
+    "issues": "Incidencias abiertas",
+    "resources": "Recursos",
+    "repositories": "Repositorios"
   },
   "why": {
     "cards": {

--- a/src/components/faq-page.tsx
+++ b/src/components/faq-page.tsx
@@ -217,7 +217,7 @@ export function FaqPage() {
                         m: monoChunk,
                         spec: inlineLink(SPEC_URL),
                         rashid: inlineLink(RASHID_URL, true),
-                        roadmap: inlineLink(COMMUNITY_LINKS.issues),
+                        roadmap: inlineLink(COMMUNITY_LINKS.roadmap),
                       })}
                     </p>
                   ))}

--- a/src/components/faq-page.tsx
+++ b/src/components/faq-page.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { useTranslations } from "next-intl";
+import { COMMUNITY_LINKS } from "@/lib/site";
 import { AWAY_ITEMS, SiteShell } from "./site-rail";
 import { monoChunk } from "./ui";
 
@@ -27,7 +28,6 @@ import { monoChunk } from "./ui";
 
 const SPEC_URL = "https://github.com/portolan-sdi/portolan-spec";
 const RASHID_URL = "https://github.com/portolan-sdi/rashid";
-const ROADMAP_URL = "https://github.com/portolan-sdi";
 
 // `paras` is the paragraph count for that answer, so each item renders exactly
 // the keys it has.
@@ -217,7 +217,7 @@ export function FaqPage() {
                         m: monoChunk,
                         spec: inlineLink(SPEC_URL),
                         rashid: inlineLink(RASHID_URL, true),
-                        roadmap: inlineLink(ROADMAP_URL),
+                        roadmap: inlineLink(COMMUNITY_LINKS.issues),
                       })}
                     </p>
                   ))}

--- a/src/components/get-involved-section.tsx
+++ b/src/components/get-involved-section.tsx
@@ -69,7 +69,7 @@ export function GetInvolvedSection() {
               ),
               issues: (chunks) => (
                 <a
-                  href={COMMUNITY_LINKS.openIssues}
+                  href={COMMUNITY_LINKS.issues}
                   className={proseLink}
                   {...external}
                 >

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -4,8 +4,12 @@ import { COMMUNITY_LINKS, LICENSE_LINKS } from "@/lib/site";
 import { PortolanLogo } from "./portolan-logo";
 import { Ltr, monoChunk } from "./ui";
 
-const licenseLink =
-  "underline underline-offset-2";
+const licenseLink = "underline underline-offset-2";
+
+const external = { target: "_blank", rel: "noopener noreferrer" } as const;
+
+const columnLabel = "mb-2 font-mono text-eyebrow text-p-ink-3";
+const footLink = "text-p-ink-2 transition-colors hover:text-p-primary";
 
 export function SiteFooter() {
   const t = useTranslations();
@@ -13,33 +17,104 @@ export function SiteFooter() {
   return (
     <footer className="px-[var(--p-pad-section-x)] pb-6 pt-10">
       <div className="mx-auto max-w-[1240px]">
-        <div className="flex flex-col items-start gap-6 sm:flex-row sm:gap-10">
-          <Link href="/" aria-label={t("nav.homeAria")} className="w-fit">
+        {/* Logo on the inline-start edge, the link columns beside it. The
+            rail indexes the page, so every destination that leaves the page
+            lives here instead. */}
+        <div className="flex flex-col items-start gap-8 sm:flex-row sm:gap-12 lg:gap-20">
+          <Link
+            href="/"
+            aria-label={t("nav.homeAria")}
+            className="block w-fit shrink-0"
+          >
             <PortolanLogo size={30} />
           </Link>
 
-          <div className="text-start text-small">
-            <p className="mb-2 font-mono text-eyebrow text-p-ink-3">
-              {t("footer.contact")}
-            </p>
-            <div className="flex flex-col items-start gap-1">
-              <a
-                href={COMMUNITY_LINKS.googleGroup}
-                className="text-p-ink-2 transition-colors hover:text-p-primary"
-              >
-                {t("footer.googleGroup")}
-              </a>
-              <a
-                href={COMMUNITY_LINKS.slack}
-                className="text-p-ink-2 transition-colors hover:text-p-primary"
-              >
-                <Ltr>{t.rich("footer.slack", { m: monoChunk })}</Ltr>
-              </a>
+          <div className="grid w-full grid-cols-1 gap-8 text-start text-small sm:grid-cols-3 sm:gap-10">
+            <div>
+              <p className={columnLabel}>{t("footer.development")}</p>
+              <ul className="flex flex-col items-start gap-1">
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.repositories}
+                    {...external}
+                    className={footLink}
+                  >
+                    {t("footer.repositories")}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.github}
+                    {...external}
+                    className={footLink}
+                  >
+                    {t("footer.githubOrg")}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.issues}
+                    {...external}
+                    className={footLink}
+                  >
+                    {t("footer.issues")}
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className={columnLabel}>{t("footer.community")}</p>
+              <ul className="flex flex-col items-start gap-1">
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.googleGroup}
+                    {...external}
+                    className={footLink}
+                  >
+                    {t("footer.googleGroup")}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.slack}
+                    {...external}
+                    className={footLink}
+                  >
+                    <Ltr>{t("footer.slack")}</Ltr>
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className={columnLabel}>{t("footer.resources")}</p>
+              <ul className="flex flex-col items-start gap-1">
+                <li>
+                  <a
+                    href={COMMUNITY_LINKS.docs}
+                    {...external}
+                    className={footLink}
+                  >
+                    {t("nav.docs")}
+                  </a>
+                </li>
+                <li>
+                  <Link href="/#resources" className={footLink}>
+                    {t("resources.title")}
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/faq" className={footLink}>
+                    {t("nav.faq")}
+                  </Link>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
 
-        <p className="mt-10 text-center text-small text-p-ink-3">
+        <p className="mt-12 text-center text-small text-p-ink-3">
           {t.rich("footer.contentLicense", {
             m: monoChunk,
             cc: (chunks) => (

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -35,11 +35,11 @@ export function SiteFooter() {
               <ul className="flex flex-col items-start gap-1">
                 <li>
                   <a
-                    href={COMMUNITY_LINKS.repositories}
+                    href={COMMUNITY_LINKS.roadmap}
                     {...external}
                     className={footLink}
                   >
-                    {t("footer.repositories")}
+                    {t("footer.roadmap")}
                   </a>
                 </li>
                 <li>
@@ -48,16 +48,7 @@ export function SiteFooter() {
                     {...external}
                     className={footLink}
                   >
-                    {t("footer.githubOrg")}
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href={COMMUNITY_LINKS.issues}
-                    {...external}
-                    className={footLink}
-                  >
-                    {t("footer.issues")}
+                    <Ltr>{t("footer.github")}</Ltr>
                   </a>
                 </li>
               </ul>
@@ -90,15 +81,6 @@ export function SiteFooter() {
             <div>
               <p className={columnLabel}>{t("footer.resources")}</p>
               <ul className="flex flex-col items-start gap-1">
-                <li>
-                  <a
-                    href={COMMUNITY_LINKS.docs}
-                    {...external}
-                    className={footLink}
-                  >
-                    {t("nav.docs")}
-                  </a>
-                </li>
                 <li>
                   <Link href="/#resources" className={footLink}>
                     {t("resources.title")}

--- a/src/components/site-rail.tsx
+++ b/src/components/site-rail.tsx
@@ -6,21 +6,20 @@ import { Link } from "@/i18n/navigation";
 import { PortolanLogo } from "./portolan-logo";
 import { LocaleSwitcher } from "./locale-switcher";
 import { SiteFooter } from "./site-footer";
-import { DirArrow } from "./ui";
 
-// Primary navigation lives in a left rail (replaces the old minimal header +
-// footer nav). On md+ the rail is permanently pinned and the page is inset by
-// --p-rail. Below md the rail is an off-canvas drawer opened from a mono
-// "Index" button. Section labels reuse the existing section eyebrows so copy
-// stays in one place.
+// Primary navigation lives in a left rail (replaces the old minimal header).
+// On md+ the rail is permanently pinned and the page is inset by --p-rail.
+// Below md the rail is an off-canvas drawer opened from a mono "Index"
+// button. Section labels reuse the existing section eyebrows so copy stays in
+// one place.
+//
+// The rail indexes the page and nothing else. Every destination that leaves
+// the page (docs, GitHub, roadmap, issues) lives in SiteFooter instead.
 //
 // The item list is a prop so a standalone page can index its own contents
 // instead of the homepage's. An item with no `href` is an in-page anchor; an
 // item with one is a route, and routes use the locale-aware Link so /es and
 // /ar keep their prefix.
-
-const DOCS_URL = "https://portolan-sdi.github.io/portolan-cli";
-const GITHUB_URL = "https://github.com/portolan-sdi";
 
 export type RailItem = {
   /** Element id on the current page, and the React key. */
@@ -140,8 +139,6 @@ export function SiteShell({
 
   const navLinkBase =
     "flex items-center justify-between gap-2 py-[9px] text-body transition-colors";
-  const groupLabelClass =
-    "px-[22px] pt-4 pb-1.5 font-mono text-eyebrow tracking-[0.04em] text-p-ink-3";
 
   return (
     <div className="min-h-screen bg-p-bg font-sans">
@@ -199,26 +196,6 @@ export function SiteShell({
                 </li>
               );
             })}
-          </ul>
-
-          <div className={groupLabelClass}>{t("nav.external")}</div>
-          <ul className="px-[22px]">
-            <li>
-              <a
-                href={DOCS_URL}
-                className={`${navLinkBase} text-p-ink hover:text-p-primary`}
-              >
-                {t("nav.docs")} <DirArrow kind="external" />
-              </a>
-            </li>
-            <li>
-              <a
-                href={GITHUB_URL}
-                className={`${navLinkBase} text-p-ink hover:text-p-primary`}
-              >
-                GitHub <DirArrow kind="external" />
-              </a>
-            </li>
           </ul>
         </div>
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -12,9 +12,17 @@ export const SITE_ORIGIN = "https://www.portolan-sdi.org";
  * Keep these aligned with portolan-ops/copy/urls.md.
  */
 export const COMMUNITY_LINKS = {
+  docs: "https://portolan-sdi.github.io/portolan-cli",
   github: "https://github.com/portolan-sdi",
   googleGroup: "https://groups.google.com/g/portolan",
-  openIssues: "https://github.com/orgs/portolan-sdi/projects/1/views/2",
+  /**
+   * Every open issue across the org. Uses global search, not the
+   * `github.com/issues?q=` dashboard, which asks a logged-out reader to sign
+   * in before it shows anything.
+   */
+  issues:
+    "https://github.com/search?q=org%3Aportolan-sdi+is%3Aissue+is%3Aopen&type=issues",
+  repositories: "https://github.com/orgs/portolan-sdi/repositories",
   slack: "https://cloudnativegeo.slack.com/archives/C0A1JBH9529",
 } as const;
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -12,7 +12,6 @@ export const SITE_ORIGIN = "https://www.portolan-sdi.org";
  * Keep these aligned with portolan-ops/copy/urls.md.
  */
 export const COMMUNITY_LINKS = {
-  docs: "https://portolan-sdi.github.io/portolan-cli",
   github: "https://github.com/portolan-sdi",
   googleGroup: "https://groups.google.com/g/portolan",
   /**
@@ -22,7 +21,11 @@ export const COMMUNITY_LINKS = {
    */
   issues:
     "https://github.com/search?q=org%3Aportolan-sdi+is%3Aissue+is%3Aopen&type=issues",
-  repositories: "https://github.com/orgs/portolan-sdi/repositories",
+  /**
+   * The roadmap is a file in portolan-ops, not the org project board. That
+   * board is private, so a public page cannot link it.
+   */
+  roadmap: "https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md",
   slack: "https://cloudnativegeo.slack.com/archives/C0A1JBH9529",
 } as const;
 


### PR DESCRIPTION
Resolves #72.

## What changed

The footer carries three columns beside the logo. The logo sits on the
inline-start edge. The license line stays centered below both. Each column
holds two links.

| Column | Links |
|---|---|
| Development | Roadmap, GitHub |
| Community | Google Group, Slack |
| Resources | Talks and demos, FAQ |

"Contact" becomes "Community". The Slack label drops the channel name and
reads "Slack". The label needs no rich text now.

The rail drops its "External" group. It lists the eight page sections and
nothing else. `GITHUB_URL` moves into `COMMUNITY_LINKS` in
`src/lib/site.ts`.

Two dead links now point at public pages.

| File | Was | Now |
|---|---|---|
| `src/components/faq-page.tsx` | the org root, called "project roadmap" | `ROADMAP.md` in portolan-ops |
| `src/components/get-involved-section.tsx` | a private board view | the open issue search |

The roadmap is a file, not a board. `copy/urls.md` in portolan-ops names
`https://github.com/orgs/portolan-sdi/projects/1` as the roadmap. That board
is private and returns 404 to a visitor. The real roadmap is
[ROADMAP.md](https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md).
Fix the `copy/urls.md` entry in portolan-ops.

`COMMUNITY_LINKS.issues` uses `github.com/search?q=...&type=issues`. The
`github.com/issues?q=...` form is the personal dashboard. It asks a
logged-out reader to sign in. The get involved section reads this constant.

The `nav.external`, `nav.docs`, and `footer.issues` keys are gone from all
three message files. Five keys join `footer`. The key sets stay identical
across `en`, `es`, and `ar`.

### Note for the reviewer

Two changes reach past the footer. Both fix one defect. A public page
links a page that a visitor cannot open. `get-involved-section.tsx` and
`faq-page.tsx` each carried one such link. Revert those two changes to keep
this pull request inside the footer.

## Why

The footer held one group of two links. A reader who reached the bottom of
the page found no way out. The roadmap, the code, and the FAQ all sat
somewhere else. They sat in the rail or inside section prose.

The rail did two jobs. It indexed the page. It also carried an "External"
group with Docs and GitHub. Those two links leave the page. A page index is
the wrong place for them.

Two links pointed at pages a visitor cannot open. The FAQ named the org root
as the "project roadmap". The get involved section named a private project
board.

## Verification

Data read: the live site at `http://localhost:3000`. Also the outbound URLs
below.

Rendered `href` values, read out of the served HTML:

```
$ curl -s http://localhost:3000/ | (extract the <footer> block)
cols: ['Development', 'Community', 'Resources']
Roadmap          https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md
GitHub           https://github.com/portolan-sdi
Google Group     https://groups.google.com/g/portolan
Slack            https://cloudnativegeo.slack.com/archives/C0A1JBH9529
Talks & demos    /#resources
FAQ              /faq
```

Each outbound URL, requested with no credentials:

```
$ for u in ...; do curl -s -o /dev/null -w '%{http_code}' -L "$u"; done
200 https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md
200 https://github.com/portolan-sdi
200 https://groups.google.com/g/portolan
403 https://cloudnativegeo.slack.com/archives/C0A1JBH9529
```

Slack returns 403 to a reader outside the workspace. That is how a Slack
channel URL behaves. This pull request does not change that link.

The private board still returns 404, which is why the roadmap link moved:

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    https://github.com/orgs/portolan-sdi/projects/1
404
```

The FAQ answer now links the roadmap file:

```
$ curl -s http://localhost:3000/faq | grep -o 'href="[^"]*"[^>]*>project roadmap'
href="https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md" ...>project roadmap
```

The footer renders in every locale. Internal links keep the locale prefix:

```
-- es
cols: ['Desarrollo', 'Comunidad', 'Recursos']
Hoja de ruta         https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md
GitHub               https://github.com/portolan-sdi
Charlas y demos      /es#resources
Preguntas frecuentes /es/faq

-- ar
cols: ['التطوير', 'المجتمع', 'الموارد']
خارطة الطريق          https://github.com/portolan-sdi/portolan-ops/blob/main/ROADMAP.md
GitHub                https://github.com/portolan-sdi
محاضرات وتجارب        /ar#resources
الأسئلة الشائعة       /ar/faq
```

The rail lists eight sections and no "External" group, in all three locales:

```
en: 8 entries | External present: False
    Why Portolan, Who it's for, How it works, Ecosystem, Talks & demos,
    Get involved, Registry, FAQ
es: 8 entries | External present: False
    Por qué Portolan, Para quién es, Cómo funciona, Ecosistema,
    Charlas y demos, Participa, Registro, Preguntas frecuentes
ar: 8 entries | External present: False
    لماذا Portolan, لمن هو, كيف يعمل, المنظومة, محاضرات وتجارب, شارك,
    السجل, الأسئلة الشائعة
```

The message files keep identical key sets:

```
$ python3 -c "import json; ..."
parity: True | ['community', 'contentLicense', 'development', 'github',
'googleGroup', 'resources', 'roadmap', 'slack', 'sourceLicense']
```

No reference to a removed key survives:

```
$ grep -rn "openIssues\|nav.external\|nav.docs\|footer.issues\|COMMUNITY_LINKS.docs" src/ messages/
none
```

The build and the linter pass:

```
$ pnpm build
✓ Compiled successfully in 7.2s

$ npx eslint src/components/site-footer.tsx src/components/site-rail.tsx \
    src/components/faq-page.tsx src/components/get-involved-section.tsx \
    src/lib/site.ts
✓ ESLint: No issues found
```