### PR TITLE
fix(hero): pin the glyph map to LTR in every locale

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -472,8 +472,10 @@ body {
    step only five times a second whatever the frame rate.
 
    The distance and the duration come from the component, which measures a
-   world span after layout. Direction-aware, to match the marquee. Under
-   reduced motion the track holds still. */
+   world span after layout. The map is a raster of text glyphs, so the frame
+   is pinned to `dir="ltr"` in the component and the drift never mirrors. The
+   map reads the same in every locale. Under reduced motion the track holds
+   still. */
 .glyph-drift {
   display: flex;
   width: max-content;
@@ -491,18 +493,15 @@ body {
     transform: translateX(calc(-1 * var(--glyph-drift-distance, 0px)));
   }
 }
-[dir="rtl"] .glyph-drift[data-drifting="true"] {
-  animation-direction: reverse;
-}
 
 /* --- Supporter logo marquee --------------------------------------------
    The strip auto-scrolls as a seamless ticker: two identical tracks sit
    side by side and the pair translates by exactly one track width, so the
    loop has no seam. Hover or focus pauses it; both inline edges fade so
    logos drift in and out instead of clipping. The track runs against the hero
-   glyph map above it, and both flip on an RTL page, so the two stay opposed in
-   either direction. The logos themselves never mirror, only the track
-   translates.
+   glyph map above it. The map holds one direction in every locale, so the
+   strip flips on an RTL page and the two stay opposed there. The logos
+   themselves never mirror, only the track translates.
    Under reduced-motion the clone is dropped and the single row wraps flat. */
 .logo-strip {
   --logo-gap: clamp(1.75rem, 4vw, 3.5rem);

--- a/src/components/glyph-map-canvas.tsx
+++ b/src/components/glyph-map-canvas.tsx
@@ -299,9 +299,13 @@ export default function GlyphMapCanvas({
 
   if (failed) return null;
 
+  // The map is a raster of text glyphs, so a right-to-left page reverses every
+  // glyph row and flips the tile order. The frame stays LTR in every locale,
+  // the same way a terminal block does.
   return (
     <div
       ref={frameRef}
+      dir="ltr"
       className={`relative overflow-hidden pointer-events-none transition-opacity duration-700 ${
         ready ? "opacity-100" : "opacity-0"
       } ${className}`}


### PR DESCRIPTION
Resolves #74.

The hero map draws the same world in every locale. The Arabic page no longer mirrors it.

## What changed

`src/components/glyph-map-canvas.tsx` sets `dir="ltr"` on the map frame. One attribute pins three things. It pins the order of the glyph rows, the flex main axis, and the child track. A terminal block in this repo carries the same attribute for the same reason.

`src/app/globals.css` drops this rule:

```css
[dir="rtl"] .glyph-drift[data-drifting="true"] {
  animation-direction: reverse;
}
```

Two comment blocks described the old behavior. Both now describe the current behavior. The logo marquee still mirrors on a right-to-left page. The map holds one direction, so the two strips stay opposed there.

## Why

Three rules mirrored the map. Each rule acted on its own. Issue #74 records them.

| Rule | Effect on a right-to-left page |
|---|---|
| The renderer writes the world as rows of ASCII characters. | The browser reorders every row. The world draws backwards. |
| The track uses `display: flex`. | The main axis reverses. The world tiles stack against the opposite edge. |
| The drift override under `[dir="rtl"]`. | The map travels the wrong way. |

The offscreen stage stays at `left: 0`. The tiles moved and the stage did not, so the seam broke.

The map is decoration. It carries `aria-hidden="true"` and it holds no text. The page direction must not touch it. `AGENTS.md` states the rule. Never mirror the map or the dither canvas.

## Verification

The build compiles all three locales.

```
$ pnpm build
├ ● /[locale]                    1h      1y
│ ├ /en                          1h      1y
│ ├ /es                          1h      1y
│ └ /ar                          1h      1y
```

The compiled client chunk carries the attribute on the map frame.

```
$ grep -o 'dir:"ltr"[^}]\{0,80\}' .next/static/chunks/447e510f0b5bm.js
dir:"ltr",className:`relative overflow-hidden pointer-events-none transition-opacity dura
```

No rule targets the drift track under `[dir="rtl"]` anymore.

```
$ grep -n "rtl" src/app/globals.css | grep -i glyph
$ echo "exit=$?"
exit=1
```

The map reads the baked relief grid at `public/data/world-relief.json`. Compare the hero on https://www.portolan-sdi.org/ and https://www.portolan-sdi.org/ar on the preview deployment. The world draws the same in both. The seam closes in both.

ESLint reports no problem in either changed file.
