### PR TITLE
fix(registry): restore coverage map performance

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -27,6 +27,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:unit
-      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm exec playwright install --with-deps chromium firefox
       - run: pnpm build
       - run: pnpm test:a11y

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      testIgnore: "**/firefox-registry.spec.ts",
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+      testMatch: "**/firefox-registry.spec.ts",
     },
   ],
 });

--- a/src/app/api/registry-coverage/route.ts
+++ b/src/app/api/registry-coverage/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { getCoverageBboxes } from "@/lib/catalogs";
 import { dedupeCoverage } from "@/lib/collection-points";
 
+// Next.js 16 does not cache GET route handlers by default. This response only
+// depends on the tagged registry export, so cache the complete response too.
+export const dynamic = "force-static";
+
 export async function GET() {
   try {
     const coverage = dedupeCoverage(await getCoverageBboxes());

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -13,6 +13,7 @@ import {
   type MapRef,
 } from "react-map-gl/maplibre";
 import type { CollectionPoint, CoverageIndex, Viewport } from "@/lib/collection-points";
+import { neutralizeMarkerHosts } from "@/lib/marker-hosts";
 import { MapGeocoder } from "./map-geocoder";
 import type { GeocodeSuggestion } from "@/hooks/use-geocode";
 
@@ -293,19 +294,9 @@ export default function CatalogMap({
     const mapContainer = mapRef.current?.getContainer();
     if (!mapContainer) return;
 
-    const neutralizeMarkerHosts = () => {
-      mapContainer.querySelectorAll<HTMLElement>(".maplibregl-marker").forEach((marker) => {
-        // Firefox reports unchanged attribute writes as new mutations.
-        if (marker.hasAttribute("aria-label")) marker.removeAttribute("aria-label");
-        if (marker.getAttribute("role") !== "presentation") {
-          marker.setAttribute("role", "presentation");
-        }
-        if (marker.hasAttribute("tabindex")) marker.removeAttribute("tabindex");
-      });
-    };
-
-    neutralizeMarkerHosts();
-    const observer = new MutationObserver(neutralizeMarkerHosts);
+    const neutralize = () => neutralizeMarkerHosts(mapContainer);
+    neutralize();
+    const observer = new MutationObserver(neutralize);
     observer.observe(mapContainer, {
       childList: true,
       subtree: true,

--- a/src/components/registry/catalog-map.tsx
+++ b/src/components/registry/catalog-map.tsx
@@ -295,9 +295,12 @@ export default function CatalogMap({
 
     const neutralizeMarkerHosts = () => {
       mapContainer.querySelectorAll<HTMLElement>(".maplibregl-marker").forEach((marker) => {
-        marker.removeAttribute("aria-label");
-        marker.setAttribute("role", "presentation");
-        marker.removeAttribute("tabindex");
+        // Firefox reports unchanged attribute writes as new mutations.
+        if (marker.hasAttribute("aria-label")) marker.removeAttribute("aria-label");
+        if (marker.getAttribute("role") !== "presentation") {
+          marker.setAttribute("role", "presentation");
+        }
+        if (marker.hasAttribute("tabindex")) marker.removeAttribute("tabindex");
       });
     };
 

--- a/src/lib/marker-hosts.ts
+++ b/src/lib/marker-hosts.ts
@@ -1,0 +1,11 @@
+/** Remove MapLibre wrapper semantics from markers that contain real buttons. */
+export function neutralizeMarkerHosts(mapContainer: ParentNode) {
+  mapContainer.querySelectorAll<HTMLElement>(".maplibregl-marker").forEach((marker) => {
+    // Firefox reports unchanged attribute writes as new mutations.
+    if (marker.hasAttribute("aria-label")) marker.removeAttribute("aria-label");
+    if (marker.getAttribute("role") !== "presentation") {
+      marker.setAttribute("role", "presentation");
+    }
+    if (marker.hasAttribute("tabindex")) marker.removeAttribute("tabindex");
+  });
+}

--- a/tests/firefox-registry.spec.ts
+++ b/tests/firefox-registry.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test("registry markers do not block the Firefox main thread", async ({ page }) => {
+  await page.route("https://basemaps.cartocdn.com/gl/positron-gl-style/style.json", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ version: 8, sources: {}, layers: [] }),
+    }),
+  );
+
+  await page.goto("/registry", { waitUntil: "domcontentloaded" });
+
+  // The old observer loop kept Firefox busy for about 44 seconds here.
+  await expect(page.locator(".maplibregl-marker button").first()).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const before = await page.evaluate(() => performance.now());
+  await page.waitForTimeout(250);
+  const after = await page.evaluate(() => performance.now());
+  expect(after - before).toBeLessThan(1_000);
+});

--- a/tests/firefox-registry.spec.ts
+++ b/tests/firefox-registry.spec.ts
@@ -10,12 +10,26 @@ test("registry markers do not block the Firefox main thread", async ({ page }) =
   );
 
   await page.goto("/registry", { waitUntil: "domcontentloaded" });
+  const map = page.locator(".maplibregl-map");
+  await expect(map).toBeVisible();
 
-  // The old observer loop kept Firefox busy for about 44 seconds here.
-  await expect(page.locator(".maplibregl-marker button").first()).toBeVisible({
-    timeout: 5_000,
+  await map.evaluate((container) => {
+    const marker = document.createElement("div");
+    marker.className = "maplibregl-marker";
+    marker.dataset.observerProbe = "true";
+    marker.setAttribute("aria-label", "Synthetic MapLibre marker");
+    marker.setAttribute("role", "button");
+    marker.setAttribute("tabindex", "0");
+    marker.appendChild(document.createElement("button"));
+    container.appendChild(marker);
   });
 
+  const marker = page.locator("[data-observer-probe=true]");
+  await expect(marker).toHaveAttribute("role", "presentation");
+  await expect(marker).not.toHaveAttribute("aria-label", /.+/);
+  await expect(marker).not.toHaveAttribute("tabindex", /.+/);
+
+  // The old observer loop kept Firefox busy for about 44 seconds here.
   const before = await page.evaluate(() => performance.now());
   await page.waitForTimeout(250);
   const after = await page.evaluate(() => performance.now());

--- a/tests/firefox-registry.spec.ts
+++ b/tests/firefox-registry.spec.ts
@@ -1,37 +1,48 @@
 import { expect, test } from "@playwright/test";
+import { neutralizeMarkerHosts } from "../src/lib/marker-hosts";
 
-test("registry markers do not block the Firefox main thread", async ({ page }) => {
-  await page.route("https://basemaps.cartocdn.com/gl/positron-gl-style/style.json", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ version: 8, sources: {}, layers: [] }),
-    }),
-  );
+test("marker normalization releases the Firefox main thread", async ({ page }) => {
+  test.setTimeout(10_000);
+  const source = neutralizeMarkerHosts.toString();
 
-  await page.goto("/registry", { waitUntil: "domcontentloaded" });
-  const map = page.locator(".maplibregl-map");
-  await expect(map).toBeVisible();
-
-  await map.evaluate((container) => {
+  const result = await page.evaluate(async (functionSource) => {
+    const neutralize = (0, eval)(`(${functionSource})`) as (container: ParentNode) => void;
     const marker = document.createElement("div");
     marker.className = "maplibregl-marker";
-    marker.dataset.observerProbe = "true";
     marker.setAttribute("aria-label", "Synthetic MapLibre marker");
     marker.setAttribute("role", "button");
     marker.setAttribute("tabindex", "0");
     marker.appendChild(document.createElement("button"));
-    container.appendChild(marker);
+    document.body.appendChild(marker);
+
+    let callbacks = 0;
+    const observer = new MutationObserver(() => {
+      callbacks += 1;
+      neutralize(document.body);
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["aria-label", "role", "tabindex"],
+    });
+
+    neutralize(document.body);
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    observer.disconnect();
+
+    return {
+      callbacks,
+      ariaLabel: marker.getAttribute("aria-label"),
+      role: marker.getAttribute("role"),
+      tabIndex: marker.getAttribute("tabindex"),
+    };
+  }, source);
+
+  expect(result).toEqual({
+    callbacks: 1,
+    ariaLabel: null,
+    role: "presentation",
+    tabIndex: null,
   });
-
-  const marker = page.locator("[data-observer-probe=true]");
-  await expect(marker).toHaveAttribute("role", "presentation");
-  await expect(marker).not.toHaveAttribute("aria-label", /.+/);
-  await expect(marker).not.toHaveAttribute("tabindex", /.+/);
-
-  // The old observer loop kept Firefox busy for about 44 seconds here.
-  const before = await page.evaluate(() => performance.now());
-  await page.waitForTimeout(250);
-  const after = await page.evaluate(() => performance.now());
-  expect(after - before).toBeLessThan(1_000);
 });


### PR DESCRIPTION
## What changed

The registry now caches its shared coverage response.
The marker observer now changes only attributes that need a new value.

The browser suite adds one focused Firefox test.
The Chromium accessibility matrix stays unchanged.

Resolves #91
Resolves #93

## Why

The registry had two separate performance defects.

The coverage Route Handler bypassed the Vercel response cache.
Each visit therefore invoked a serverless function before the map could start.

The marker observer also wrote an unchanged `role` value inside its own callback.
Firefox treated each write as another mutation.
This loop blocked the Firefox main thread for about 44 seconds.

## Verification

The build and browser tests read this registry coverage response:

`https://www.portolan-sdi.org/api/registry-coverage`

The coverage contract tests pass.

```console
$ pnpm test:unit
# tests 3
# suites 0
# pass 3
# fail 0
```

The production build classifies the coverage route as static.

```console
$ pnpm build
Route (app)                 Revalidate  Expire
├ ○ /api/registry-coverage          1h      1y
```

The complete browser suite passes in Chromium and Firefox.

```console
$ pnpm test:a11y
✓ 43 [firefox] › marker normalization releases the Firefox main thread (1.1s)
43 passed (24.5s)
```

Focused lint reports no errors.

```console
$ pnpm exec eslint src/components/registry/catalog-map.tsx tests/firefox-registry.spec.ts playwright.config.ts
```
