### PR TITLE
feat(registry): name the three parties behind each catalog

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -184,6 +184,8 @@
     },
     "card": {
       "viewCatalog": "عرض الكتالوج",
+      "createdBy": "أنشأه",
+      "createdByMore": "و{count} أخرى",
       "collections": "{count} مجموعة",
       "licenses": "{count} رخصة",
       "collection": "مجموعة واحدة",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -184,8 +184,10 @@
     },
     "card": {
       "viewCatalog": "عرض الكتالوج",
-      "createdBy": "أنشأه",
-      "createdByMore": "و{count} أخرى",
+      "moreProducers": "و{count} أخرى",
+      "dataSourceProducer": "منتج مصدر البيانات",
+      "processedBy": "عالجه",
+      "hostedBy": "يستضيفه",
       "collections": "{count} مجموعة",
       "licenses": "{count} رخصة",
       "collection": "مجموعة واحدة",

--- a/messages/en.json
+++ b/messages/en.json
@@ -184,8 +184,10 @@
     },
     "card": {
       "viewCatalog": "View catalog",
-      "createdBy": "created by",
-      "createdByMore": "+{count} more",
+      "moreProducers": "+{count} more",
+      "dataSourceProducer": "Data source producer",
+      "processedBy": "Processed by",
+      "hostedBy": "Hosted by",
       "collections": "{count} collections",
       "licenses": "{count} licenses",
       "collection": "1 collection",

--- a/messages/en.json
+++ b/messages/en.json
@@ -184,6 +184,8 @@
     },
     "card": {
       "viewCatalog": "View catalog",
+      "createdBy": "created by",
+      "createdByMore": "+{count} more",
       "collections": "{count} collections",
       "licenses": "{count} licenses",
       "collection": "1 collection",

--- a/messages/es.json
+++ b/messages/es.json
@@ -184,6 +184,8 @@
     },
     "card": {
       "viewCatalog": "Ver catálogo",
+      "createdBy": "creado por",
+      "createdByMore": "+{count} más",
       "collections": "{count} colecciones",
       "licenses": "{count} licencias",
       "collection": "1 colección",

--- a/messages/es.json
+++ b/messages/es.json
@@ -184,8 +184,10 @@
     },
     "card": {
       "viewCatalog": "Ver catálogo",
-      "createdBy": "creado por",
-      "createdByMore": "+{count} más",
+      "moreProducers": "+{count} más",
+      "dataSourceProducer": "Productor de la fuente de datos",
+      "processedBy": "Procesado por",
+      "hostedBy": "Alojado por",
       "collections": "{count} colecciones",
       "licenses": "{count} licencias",
       "collection": "1 colección",

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useState, type ReactNode } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Tag, DirArrow, Ltr } from "../ui";
-import type { Catalog } from "@/lib/catalogs";
+import type { Catalog, CatalogParty } from "@/lib/catalogs";
 import {
   formatBytes,
   formatCount,
@@ -85,6 +85,32 @@ function CatalogHeader({ catalog, onSelect }: CatalogProps & { onSelect?: () => 
         </div>
       </div>
     </>
+  );
+}
+
+// Who made the data, from the `producer` role on the catalog's own STAC
+// providers. Its own line rather than a run of facts: an agency name can be
+// longer than the two dotted rows below hold, and this is attribution, not
+// measurement.
+//
+// Names stay Latin-ordered on the Arabic page, the way format and license
+// names do. Two registered catalogs name no producer, and they print nothing.
+function CatalogCredit({ producers }: { producers: CatalogParty[] }) {
+  const t = useTranslations("registry");
+  const [first, ...rest] = producers;
+  if (!first) return null;
+
+  return (
+    <p
+      className="text-small text-p-ink-3 font-mono"
+      // The rest of the producers, for a catalog that credits several. A
+      // native tooltip rather than a control: the card names the lead party
+      // and gains no chrome to expand a list.
+      title={rest.length > 0 ? producers.map((p) => p.name).join(", ") : undefined}
+    >
+      {t("card.createdBy")} <Ltr>{first.name}</Ltr>
+      {rest.length > 0 && ` ${t("card.createdByMore", { count: String(rest.length) })}`}
+    </p>
   );
 }
 
@@ -187,6 +213,7 @@ export function CatalogCard({
       }`}
     >
       <CatalogHeader catalog={catalog} onSelect={select} />
+      <CatalogCredit producers={catalog.producers} />
       <CatalogFacts catalog={catalog} />
       <CatalogActions catalog={catalog} />
     </article>

--- a/src/components/registry/catalog-card.tsx
+++ b/src/components/registry/catalog-card.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useState, type ReactNode } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Tag, DirArrow, Ltr } from "../ui";
-import type { Catalog, CatalogParty } from "@/lib/catalogs";
+import type { Catalog, CatalogKind, CatalogParty } from "@/lib/catalogs";
 import {
   formatBytes,
   formatCount,
@@ -88,6 +88,30 @@ function CatalogHeader({ catalog, onSelect }: CatalogProps & { onSelect?: () => 
   );
 }
 
+/** One labelled row of the detail panel. */
+function CreditRow({
+  label,
+  value,
+  first = false,
+}: {
+  label: string;
+  value: string;
+  first?: boolean;
+}) {
+  return (
+    <>
+      <span
+        className={`block text-p-ink-3 ${first ? "" : "mt-2 border-t border-p-line-soft pt-2"}`}
+      >
+        {label}
+      </span>
+      <span className="block text-p-ink">
+        <Ltr>{value}</Ltr>
+      </span>
+    </>
+  );
+}
+
 // Who made the data, from the `producer` role on the catalog's own STAC
 // providers. Its own line rather than a run of facts: an agency name can be
 // longer than the two dotted rows below hold, and this is attribution, not
@@ -95,21 +119,88 @@ function CatalogHeader({ catalog, onSelect }: CatalogProps & { onSelect?: () => 
 //
 // Names stay Latin-ordered on the Arabic page, the way format and license
 // names do. Two registered catalogs name no producer, and they print nothing.
-function CatalogCredit({ producers }: { producers: CatalogParty[] }) {
+function CatalogCredit({
+  producers,
+  processors,
+  host,
+  kind,
+}: {
+  producers: CatalogParty[];
+  processors: CatalogParty[];
+  host: CatalogParty | null;
+  kind: CatalogKind | null;
+}) {
   const t = useTranslations("registry");
   const [first, ...rest] = producers;
   if (!first) return null;
 
+  // The face of the card names one party. The rest of the provenance opens on
+  // hover or focus, under labels that say which role each party holds.
+  //
+  // A panel rather than more lines on the face. Naming the producer answers
+  // "whose data is this", which is the question a card has room for. The other
+  // two roles matter once a reader is already interested, and 14 of the 19
+  // catalogs are mirrors, so more visible lines would land on most cards and
+  // flatten the grid.
+  //
+  // The host line appears for a mirror only. On an official catalog the host
+  // is the producer, so the line would repeat the one above it. `kind` decides
+  // that, not a comparison of the two names: planet-disasterdata is official
+  // and writes its producer "Planet Labs PBC" against its host "Planet Crisis
+  // Response Program", so the names differ where the organization does not.
+  //
+  // "Hosted by", not "maintained by", although the specification defines the
+  // host as the party that maintains the copy. Seven of the fourteen mirrors
+  // put a storage vendor in that field instead, which core.md forbids by name,
+  // so today the value answers "who serves this" and not "who runs this".
+  const serves = kind === "mirror" ? host : null;
+
+  // A processor already named as the producer or the host is dropped: the row
+  // would repeat a row beside it. What survives is the party a catalog names
+  // nowhere else, which is who actually built the copy. Four catalogs are in
+  // that position, catalog-1781203130384 among them, where the producer is an
+  // Argentine agency, the host is a storage platform, and only the processor
+  // names the person who converted the data.
+  const named = new Set(
+    [...producers, ...(host ? [host] : [])].map((p) => p.name.trim().toLowerCase())
+  );
+  const derived = processors.filter((p) => !named.has(p.name.trim().toLowerCase()));
+
+  const hasDetail = rest.length > 0 || derived.length > 0 || serves !== null;
+
   return (
-    <p
-      className="text-small text-p-ink-3 font-mono"
-      // The rest of the producers, for a catalog that credits several. A
-      // native tooltip rather than a control: the card names the lead party
-      // and gains no chrome to expand a list.
-      title={rest.length > 0 ? producers.map((p) => p.name).join(", ") : undefined}
-    >
-      {t("card.createdBy")} <Ltr>{first.name}</Ltr>
-      {rest.length > 0 && ` ${t("card.createdByMore", { count: String(rest.length) })}`}
+    <p className="group/credit relative text-small text-p-ink-3 font-mono">
+      {/* Focusable so the detail is reachable without a pointer. */}
+      <span tabIndex={hasDetail ? 0 : undefined} className="outline-p-primary">
+        {t("card.dataSourceProducer")}{" "}
+        {/* The name takes the darker ink so the eye splits it from the label. */}
+        <span className="text-p-ink">
+          <Ltr>{first.name}</Ltr>
+          {rest.length > 0 && ` ${t("card.moreProducers", { count: String(rest.length) })}`}
+        </span>
+      </span>
+      {hasDetail && (
+        // Flat paper on a black rule, square, no shadow, the way every other
+        // surface on the site reads. It opens toward the inline start so it
+        // mirrors with the page instead of running off the edge in Arabic.
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute start-0 top-full z-30 mt-1 hidden w-max max-w-[17rem] border border-p-line bg-p-paper p-2 text-start group-hover/credit:block group-focus-within/credit:block"
+        >
+          <CreditRow
+            first
+            label={t("card.dataSourceProducer")}
+            value={producers.map((p) => p.name).join(", ")}
+          />
+          {derived.length > 0 && (
+            <CreditRow
+              label={t("card.processedBy")}
+              value={derived.map((p) => p.name).join(", ")}
+            />
+          )}
+          {serves && <CreditRow label={t("card.hostedBy")} value={serves.name} />}
+        </span>
+      )}
     </p>
   );
 }
@@ -208,12 +299,21 @@ export function CatalogCard({
     <article
       data-catalog-id={catalog.id}
       aria-current={selected ? "true" : undefined}
-      className={`ec-card group flex h-full flex-col gap-3 border border-p-line bg-p-paper p-5 ${
+      // `.ec-card` carries a transform, which opens a stacking context and
+      // traps the credit detail behind whichever card follows in the DOM. The
+      // hovered card rises so its own overlay wins. Grid items take z-index
+      // without needing `position`.
+      className={`ec-card group relative flex h-full flex-col gap-3 border border-p-line bg-p-paper p-5 hover:z-20 focus-within:z-20 ${
         selected ? "outline outline-2 -outline-offset-2 outline-p-primary" : ""
       }`}
     >
       <CatalogHeader catalog={catalog} onSelect={select} />
-      <CatalogCredit producers={catalog.producers} />
+      <CatalogCredit
+        producers={catalog.producers}
+        processors={catalog.processors}
+        host={catalog.host}
+        kind={catalog.kind}
+      />
       <CatalogFacts catalog={catalog} />
       <CatalogActions catalog={catalog} />
     </article>

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -45,6 +45,8 @@ export interface Catalog {
   kind: CatalogKind | null;
   /** Who made the data, in the order the catalog names them. */
   producers: CatalogParty[];
+  /** Who derived this copy from the source. Often the mirror's own author. */
+  processors: CatalogParty[];
   /** Who serves this copy. Null when no collection names a host. */
   host: CatalogParty | null;
   /** Portolan spec version the catalog declares. Null for plain STAC. */
@@ -107,6 +109,7 @@ interface ChildLink {
   "portolan_registry:id": string;
   "portolan_registry:kind"?: string | null;
   "portolan_registry:producers"?: CatalogParty[] | null;
+  "portolan_registry:processors"?: CatalogParty[] | null;
   "portolan_registry:host"?: CatalogParty | null;
   "portolan_registry:spec_version"?: string | null;
   "portolan_registry:logo"?: CatalogLogo | null;
@@ -159,6 +162,10 @@ function toParty(value: unknown): CatalogParty | null {
   return typeof url === "string" && url ? { name, url } : { name };
 }
 
+function toParties(value: CatalogParty[] | null | undefined): CatalogParty[] {
+  return (value ?? []).map(toParty).filter((p): p is CatalogParty => p !== null);
+}
+
 function toCatalog(link: ChildLink): Catalog {
   const logo = link["portolan_registry:logo"];
 
@@ -167,9 +174,8 @@ function toCatalog(link: ChildLink): Catalog {
     url: link.href,
     title: link.title ?? link["portolan_registry:id"],
     kind: toKind(link["portolan_registry:kind"]),
-    producers: (link["portolan_registry:producers"] ?? [])
-      .map(toParty)
-      .filter((p): p is CatalogParty => p !== null),
+    producers: toParties(link["portolan_registry:producers"]),
+    processors: toParties(link["portolan_registry:processors"]),
     host: toParty(link["portolan_registry:host"]),
     spec_version: link["portolan_registry:spec_version"] ?? null,
     bbox: isBbox(link.bbox) ? link.bbox : null,

--- a/src/lib/catalogs.ts
+++ b/src/lib/catalogs.ts
@@ -24,16 +24,29 @@ export interface CatalogLogo {
 }
 
 // Whether the publisher runs the authoritative copy or re-hosts someone
-// else's. The registry does not export this yet, so it is null for every
-// catalog today and the UI hides the control that filters on it. See
-// https://github.com/portolan-sdi/portolan-registry/issues (kind field).
+// else's. The registry derives this from each collection's STAC `providers`
+// rather than reading a declared field: portolan-spec (core.md, Source
+// Provenance) defines a catalog as official when its producer and host are
+// the same organization. Null when a catalog's providers name no producer or
+// no host, which two registered catalogs do today.
 export type CatalogKind = "official" | "mirror";
+
+// One organization a catalog names. `url` is absent when the catalog gives
+// none, which the spec permits for a producer.
+export interface CatalogParty {
+  name: string;
+  url?: string;
+}
 
 export interface Catalog {
   id: string;
   url: string;
   title: string;
   kind: CatalogKind | null;
+  /** Who made the data, in the order the catalog names them. */
+  producers: CatalogParty[];
+  /** Who serves this copy. Null when no collection names a host. */
+  host: CatalogParty | null;
   /** Portolan spec version the catalog declares. Null for plain STAC. */
   spec_version: string | null;
   bbox: [number, number, number, number] | null;
@@ -93,6 +106,8 @@ interface ChildLink {
   bbox?: [number, number, number, number] | null;
   "portolan_registry:id": string;
   "portolan_registry:kind"?: string | null;
+  "portolan_registry:producers"?: CatalogParty[] | null;
+  "portolan_registry:host"?: CatalogParty | null;
   "portolan_registry:spec_version"?: string | null;
   "portolan_registry:logo"?: CatalogLogo | null;
   "portolan_registry:collection_count"?: number | null;
@@ -135,6 +150,15 @@ function toKind(value: unknown): CatalogKind | null {
   return value === "official" || value === "mirror" ? value : null;
 }
 
+// A party is only useful if it has a name to print. The registry publishes
+// what a catalog declares, and one entry today names itself "TODO: Add value".
+function toParty(value: unknown): CatalogParty | null {
+  if (!value || typeof value !== "object") return null;
+  const { name, url } = value as { name?: unknown; url?: unknown };
+  if (typeof name !== "string" || !name.trim()) return null;
+  return typeof url === "string" && url ? { name, url } : { name };
+}
+
 function toCatalog(link: ChildLink): Catalog {
   const logo = link["portolan_registry:logo"];
 
@@ -143,6 +167,10 @@ function toCatalog(link: ChildLink): Catalog {
     url: link.href,
     title: link.title ?? link["portolan_registry:id"],
     kind: toKind(link["portolan_registry:kind"]),
+    producers: (link["portolan_registry:producers"] ?? [])
+      .map(toParty)
+      .filter((p): p is CatalogParty => p !== null),
+    host: toParty(link["portolan_registry:host"]),
     spec_version: link["portolan_registry:spec_version"] ?? null,
     bbox: isBbox(link.bbox) ? link.bbox : null,
     logo: logo && logo.href ? logo : null,


### PR DESCRIPTION
## What changed

Each registry card names the parties behind a catalog, by the role each one
holds. The face of the card reads "Data source producer" and the first
producer. A panel opens on hover or on focus and adds the rest:

- every other producer,
- "Processed by", the party that derived this copy,
- "Hosted by", the party that serves it.

The diff touches five files:

- `src/lib/catalogs.ts`: `producers`, `processors`, and `host` on `Catalog` and
  `ChildLink`, read through a `toParty` guard that drops an unnamed entry.
- `src/components/registry/catalog-card.tsx`: `CatalogCredit` and `CreditRow`.
- `messages/en.json`, `messages/es.json`, `messages/ar.json`: four keys under
  `registry.card`.

Resolves #114.

## Why

The card said nothing about who made the data. The registry lists 19 catalogs,
and 14 of them re-host data that somebody else produced. A visitor who cites a
dataset needs the name of the party that made it.

The canonical org copy already promises this, in `copy/messaging.md`:

> It also makes provenance visible: every catalog names its producer, its
> provider, and its host using the STAC provider extension.

Issue #106 covers the mirror paragraph in the hero. It puts the card out of
scope. The export carried no field to read. portolan-registry#122 publishes
the three fields this branch reads.

The Mirror and Official badge needs no work here. The card renders it already,
and all three locales carry the label. It appears in the screenshots below
because the same export feeds it.

## Three roles, three rows

Each row appears only where it adds a party the card does not already name.

The host row appears for a mirror only. The host of an official catalog is its
producer, so the row would repeat the row above it.

`kind` decides that, not a comparison of the two names. planet-disasterdata is official. It writes its
producer "Planet Labs PBC" against its host "Planet Crisis Response Program".
The names differ where the organization does not.

The card drops a processor that it already names as a producer or as the host.
Across the 19 catalogs, 5 name a processor that is neither. 3 name the host
again, 4 name a producer again, and 7 name none.

The label reads "Hosted by" and not "maintained by". The specification defines
the host as the party that maintains the copy, in `specs/portolan/core.md`. 7
of the 14 mirrors put a storage vendor in that field instead, which the same
paragraph forbids by name. So today the value answers "who serves this" rather
than "who runs this". The processor row names the second party for the catalogs
that declare one.

## Verification

The registry export on `main` does not carry the new fields yet, because
portolan-registry#122 still waits for a merge. So I ran the registry crawler
locally, served its output, and pointed `CATALOGS_URL` at it. That patch is not
in this branch.

```
$ cd ../portolan-registry && uv run --frozen scripts/publish_export.py --output -
```

Each row renders only where it adds a party. Read back from the production
build:

```
$ curl -s http://127.0.0.1:3100/registry | python3 -c "
import sys,re
h=sys.stdin.read()
for m in re.finditer(r'data-catalog-id=\"([^\"]+)\"(.*?)</article>', h, re.S):
    cid, body = m.group(1), m.group(2)
    rows=[l for l in ('Data source producer','Processed by','Hosted by') if l in body]
    print(f'{cid:32} {rows}')
"

bot-open-data                    ['Data source producer']
cadastral                        ['Data source producer', 'Hosted by']
carto-do                         ['Data source producer', 'Processed by', 'Hosted by']
catalog                          []
catalog-1781203130384            ['Data source producer', 'Processed by', 'Hosted by']
ghsl                             ['Data source producer', 'Hosted by']
```

The card for `catalog` prints nothing, because that catalog names no producer.
The cards for `cadastral` and `ghsl` drop the processor row, because each names
its host again.

The gate passes:

```
$ npx eslint
(no findings)

$ npx tsc --noEmit
(no findings)

$ npx tsx --test tests/coverage-contract.test.ts
tests 3
pass 3
fail 0

$ next build
✓ Compiled successfully in 2.9s
✓ Generating static pages using 14 workers (23/23) in 1387ms
```

The key sets stay identical across the three locales, at 286 keys each.

The Playwright suite reports 42 passed against the production build. One test
fails on my machine, `tests/firefox-registry.spec.ts`, which measures the
Firefox main thread. It fails the same way with this branch stashed. CI reports
the a11y job green on the earlier commit of this branch.

## Screenshots

The branch `pr-115-screenshots` hosts these images. Delete it after the merge.

The panel on `catalog-1781203130384`. Its producer is an Argentine agency, and
its host is a storage platform. Only its processor names the person who
converted the data:

![The credit panel on the Argentine mirror](https://raw.githubusercontent.com/portolan-sdi/portolan-sdi.org/pr-115-screenshots/lbl-en-ign.png)

The catalog `carto-do` credits nine producers. The panel lists them all:

![The credit panel on the CARTO catalog](https://raw.githubusercontent.com/portolan-sdi/portolan-sdi.org/pr-115-screenshots/lbl-en-carto.png)

Arabic. The panel opens from the inline start, the labels set right to left,
and the party names stay Latin-ordered:

![The credit panel on the Arabic page](https://raw.githubusercontent.com/portolan-sdi/portolan-sdi.org/pr-115-screenshots/lbl-ar-carto.png)

Registry cards in English, then in Spanish:

![Registry cards in English](https://raw.githubusercontent.com/portolan-sdi/portolan-sdi.org/pr-115-screenshots/card-en.png)

![Registry cards in Spanish](https://raw.githubusercontent.com/portolan-sdi/portolan-sdi.org/pr-115-screenshots/card-es.png)

## Notes

- The panel is flat paper on a black rule with square corners and no shadow. A
  native `title` tooltip came first. It cannot reach a touch screen, and a
  browser draws it outside the page, so no screenshot can show it.
- The hovered card rises. `.ec-card` carries a transform, which opens its own
  paint layer. That layer trapped the panel behind the next card in the grid. A
  grid item takes `z-index` without `position`.
- The credit line is focusable, so a keyboard reaches the panel.
- Party names are plain text, not links. The export carries a `url` for most
  parties, and the card already holds two actions.
- The open PR #112 edits all three message files. Expect a small conflict in
  `registry.card` when one of the two merges.
