### PR TITLE
fix(registry): derive submissions from catalog id

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -234,6 +234,7 @@
       "successTitle": "تم الإرسال!",
       "viewPr": "عرض الإرسال",
       "submitAnother": "إرسال آخر",
+      "alreadyExistsError": "يوجد كتالوج مسجل بهذا المعرّف",
       "failedError": "تعذّر الإرسال",
       "genericError": "حدث خطأ ما"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -234,6 +234,7 @@
       "successTitle": "Submitted!",
       "viewPr": "View submission",
       "submitAnother": "Submit another",
+      "alreadyExistsError": "A catalog with this ID is already registered",
       "failedError": "Submission failed",
       "genericError": "Something went wrong"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -234,6 +234,7 @@
       "successTitle": "¡Enviado!",
       "viewPr": "Ver envío",
       "submitAnother": "Enviar otro",
+      "alreadyExistsError": "Ya existe un catálogo con este ID",
       "failedError": "Error al enviar",
       "genericError": "Algo salió mal"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:unit": "tsx --test tests/coverage-contract.test.ts",
+    "test:unit": "tsx --test tests/*.test.ts",
     "test:a11y": "playwright test"
   },
   "dependencies": {

--- a/src/app/api/submit-catalog/route.ts
+++ b/src/app/api/submit-catalog/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SignJWT } from "jose";
 import { createPrivateKey } from "crypto";
+import {
+  registryEntryExists,
+  registryIdFromCatalog,
+} from "@/lib/catalog-submission";
 
 const GITHUB_APP_ID = process.env.GITHUB_APP_ID;
 const GITHUB_INSTALLATION_ID = process.env.GITHUB_INSTALLATION_ID;
@@ -19,23 +23,6 @@ interface SubmitRequest {
 // then out of reach. Rejecting whitespace matters beyond shape: this value is
 // interpolated into YAML, and a newline in it would inject a second key.
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function deriveSlug(url: string): string {
-  try {
-    const parsed = new URL(url);
-    const pathParts = parsed.pathname.split("/").filter(Boolean);
-    const catalogIndex = pathParts.findIndex((p) => p === "catalog.json");
-    if (catalogIndex > 0) {
-      return pathParts[catalogIndex - 1];
-    }
-    if (pathParts.length >= 2) {
-      return pathParts[pathParts.length - 2];
-    }
-    return `catalog-${Date.now()}`;
-  } catch {
-    return `catalog-${Date.now()}`;
-  }
-}
 
 async function getInstallationToken(): Promise<string> {
   if (!GITHUB_APP_ID || !GITHUB_INSTALLATION_ID || !GITHUB_PRIVATE_KEY) {
@@ -100,6 +87,14 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    let slug: string;
+    try {
+      slug = await registryIdFromCatalog(url);
+    } catch (err) {
+      console.error("Catalog identity error:", err);
+      return NextResponse.json({}, { status: 422 });
+    }
+
     let token: string;
     try {
       token = await getInstallationToken();
@@ -111,7 +106,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const slug = deriveSlug(url);
+    const entryUrl =
+      `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}` +
+      `/contents/catalogs/${slug}.yaml?ref=main`;
+    if (await registryEntryExists(entryUrl, token)) {
+      return NextResponse.json({}, { status: 409 });
+    }
+
     const branchName = `add-${slug}-${Date.now()}`;
 
     const mainRef = await fetch(

--- a/src/components/registry-page.tsx
+++ b/src/components/registry-page.tsx
@@ -306,6 +306,9 @@ export function RegistryPage({
       const data = await res.json();
 
       if (!res.ok) {
+        if (res.status === 409) {
+          throw new Error(t("registry.submit.alreadyExistsError"));
+        }
         throw new Error(data.error || t("registry.submit.failedError"));
       }
 

--- a/src/lib/catalog-submission.ts
+++ b/src/lib/catalog-submission.ts
@@ -1,0 +1,69 @@
+type FetchCatalog = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const CATALOG_FETCH_TIMEOUT_MS = 10_000;
+const MAX_REGISTRY_ID_LENGTH = 80;
+
+export function registryIdFromCatalogId(catalogId: unknown): string {
+  if (typeof catalogId !== "string") {
+    throw new Error("The root catalog has no string id");
+  }
+
+  const registryId = catalogId
+    .trim()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_REGISTRY_ID_LENGTH)
+    .replace(/-+$/g, "");
+
+  if (!registryId) {
+    throw new Error("The root catalog id cannot form a registry id");
+  }
+
+  return registryId;
+}
+
+export async function registryIdFromCatalog(
+  url: string,
+  fetchCatalog: FetchCatalog = fetch,
+): Promise<string> {
+  const response = await fetchCatalog(url, {
+    cache: "no-store",
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(CATALOG_FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`The root catalog returned HTTP ${response.status}`);
+  }
+
+  const catalog: unknown = await response.json();
+  if (!catalog || typeof catalog !== "object") {
+    throw new Error("The root catalog is not a JSON object");
+  }
+
+  return registryIdFromCatalogId((catalog as { id?: unknown }).id);
+}
+
+export async function registryEntryExists(
+  entryUrl: string,
+  token: string,
+  fetchEntry: FetchCatalog = fetch,
+): Promise<boolean> {
+  const response = await fetchEntry(entryUrl, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (response.ok) return true;
+  if (response.status === 404) return false;
+
+  throw new Error(`Failed to check registry id: HTTP ${response.status}`);
+}

--- a/tests/catalog-submission.test.ts
+++ b/tests/catalog-submission.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  registryEntryExists,
+  registryIdFromCatalog,
+  registryIdFromCatalogId,
+} from "../src/lib/catalog-submission";
+
+test("the registry id comes from the root catalog id", async () => {
+  let requestedUrl = "";
+  const registryId = await registryIdFromCatalog(
+    "https://example.org/releases/main/catalog.json",
+    async (input) => {
+      requestedUrl = input.toString();
+      return Response.json({
+        id: "madrid-datos-abiertos",
+        title: "Catálogo de Datos Abiertos del Ayuntamiento de Madrid",
+      });
+    },
+  );
+
+  assert.equal(requestedUrl, "https://example.org/releases/main/catalog.json");
+  assert.equal(registryId, "madrid-datos-abiertos");
+});
+
+test("catalog ids become safe registry file stems", () => {
+  assert.equal(registryIdFromCatalogId(" Île de France / 2026 "), "ile-de-france-2026");
+});
+
+test("a missing catalog id cannot fall back to the URL folder", async () => {
+  await assert.rejects(
+    registryIdFromCatalog(
+      "https://example.org/releases/main/catalog.json",
+      async () => Response.json({ title: "Example" }),
+    ),
+    /no string id/,
+  );
+});
+
+test("the website detects an existing registry id before branch creation", async () => {
+  let authorization = "";
+  const exists = await registryEntryExists(
+    "https://api.github.com/repos/portolan-sdi/portolan-registry/contents/catalogs/example.yaml?ref=main",
+    "installation-token",
+    async (_input, init) => {
+      authorization = new Headers(init?.headers).get("Authorization") ?? "";
+      return Response.json({ name: "example.yaml" });
+    },
+  );
+
+  assert.equal(exists, true);
+  assert.equal(authorization, "Bearer installation-token");
+});
+
+test("a missing registry id remains available", async () => {
+  const exists = await registryEntryExists(
+    "https://api.github.com/example.yaml",
+    "installation-token",
+    async () => new Response(null, { status: 404 }),
+  );
+
+  assert.equal(exists, false);
+});


### PR DESCRIPTION
## What changed

The submission route reads the root `catalog.json` before it creates a registry branch. It converts `catalog.id` to a safe registry ID.

The route checks `catalogs/<id>.yaml` on the registry `main` branch. It returns HTTP 409 when that registry ID exists.

The form reports the duplicate ID in English, Spanish, and Arabic. Unit tests cover ID selection, safe filenames, and the uniqueness check.

This change resolves https://github.com/portolan-sdi/portolan-sdi.org/issues/121.

## Why

Version directories do not identify catalogs. The Madrid URL contains `/main/catalog.json`, but its root catalog ID is `madrid-datos-abiertos`.

portolan-registry#124 therefore created `catalogs/main.yaml`. The registry uses the YAML filename stem as its exported registry ID.

## Verification

The first command reads `https://storage.googleapis.com/carto-open-catalogs/madrid-datos-abiertos/main/catalog.json`.

```console
$ ./node_modules/.bin/tsx -e "import { registryIdFromCatalog } from './src/lib/catalog-submission.ts'; registryIdFromCatalog('https://storage.googleapis.com/carto-open-catalogs/madrid-datos-abiertos/main/catalog.json').then((id) => console.log(id));"
madrid-datos-abiertos

$ ./node_modules/.bin/tsx --test tests/*.test.ts
ℹ tests 8
ℹ pass 8
ℹ fail 0

$ ./node_modules/.bin/eslint .

$ ./node_modules/.bin/next build
✓ Compiled successfully
✓ Generating static pages using 9 workers (23/23)
```
