### PR TITLE
fix(css): stop Tailwind reading the Markdown docs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* Tailwind v4 detects its own sources. It reads every file the repository
+   does not ignore, and that includes the Markdown docs. DESIGN.md quotes the
+   class `rounded-[var(--p-r-*)]` to describe the radius tokens. Tailwind reads
+   the quote as a real class and emits `border-radius: var(--p-r-*)`. The `*`
+   is not a valid custom property name, so the CSS parser in Turbopack stops on
+   it and every route returns 500 under `next dev`. The production build drops
+   the rule instead, so only the dev server broke.
+
+   The docs describe the design, they never ship a class, so Tailwind has no
+   reason to read them. */
+@source not "../../**/*.md";
+
 :root {
   /* Hero legibility scrim over the glyph map — light enough that the map
      stays visible. The opaque end must sit under the headline, which is


### PR DESCRIPTION
## What changed

`pnpm dev` works again. It returned 500 on every route before this change.

`src/app/globals.css` takes one `@source not` line. The line takes the Markdown files out of the scan that Tailwind runs to find classes.

This resolves #123.

## Why

Tailwind v4 finds its own source files. It reads every file the repository does not ignore, and that set includes the Markdown docs. `DESIGN.md:260` quotes the class `rounded-[var(--p-r-*)]` to describe the radius tokens. Tailwind reads the quote as a real class and emits `border-radius: var(--p-r-*)`. The `*` is not a valid custom property name, so the CSS parser in Turbopack stops on it.

A test by isolation names `DESIGN.md` as the only cause. The same text sits in a comment in `globals.css:49`, and that copy is safe, because Tailwind does not read candidates from the stylesheet it compiles.

`next build` passed all along. The production build drops the invalid rule instead of stopping, so the fault reached the dev server only.

The docs describe the design. They never ship a class, so Tailwind has no reason to read them.

## Verification

The dev server returns 200 on every route:

```
$ pnpm exec next dev -p 3005
$ for p in / /es /ar /faq /talks /registry; do
    printf "%-12s %s\n" "$p" "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3005$p)"
  done
/            200
/es          200
/ar          200
/faq         200
/talks       200
/registry    200

$ grep -c "Parsing CSS source code failed" dev.log
0
```

The same commands on `main` return 500 on all six routes.

The stylesheet loses 5 rules and gains none. A clean build of each branch:

```
$ git checkout <ref> && rm -rf .next && pnpm exec next build
$ cat .next/static/chunks/*.css | wc -c
main              137896 bytes   531 selectors
fix/next-dev-css  136935 bytes   526 selectors

$ comm -23 selectors-main.txt selectors-branch.txt
.backdrop-blur
.lg\:grid-cols-4
.shadow
.static
.text-\[13px\]

$ comm -13 selectors-main.txt selectors-branch.txt
(none)
```

No component uses any of the 5. Tailwind still reads every `.tsx` file, so a class that a component uses cannot disappear. Each of the 5 reaches the stylesheet from prose in a Markdown file:

| Class | Source |
|---|---|
| `.backdrop-blur` | `AGENTS.md:114` forbids it. "no frosted `backdrop-blur`" |
| `.text-[13px]` | `AGENTS.md:100` forbids it. "never arbitrary sizes like `text-[13px]`" |
| `.lg:grid-cols-4` | `AGENTS.md:112` gives it as an example of a grid step |
| `.shadow` | `DESIGN.md:248` describes the shadow tokens |
| `.static` | a code comment in `globals.css:534` and `force-static` in a route file |

Two of the 5 are utilities the design rules forbid. The site shipped them because the rule that forbids them names them.

A search of `src/` finds none of the 5 as a class on an element:

```
$ grep -rn --include='*.tsx' 'backdrop-blur\|lg:grid-cols-4\|text-\[13px\]' src/
(no output)
```

Gates:

```
$ pnpm exec eslint            -> exit 0
$ pnpm exec tsc --noEmit      -> exit 0
$ pnpm exec next build        -> exit 0
$ pnpm test:unit              -> 3 pass, 0 fail
```

The data read is this repository at commit ce3c04b, and `DESIGN.md` at line 260 on `main`.
