### PR TITLE
fix(faq): put the answer text back in the FAQ structured data

### DIFF
--- a/src/app/[locale]/faq/page.tsx
+++ b/src/app/[locale]/faq/page.tsx
@@ -52,10 +52,16 @@ export default async function Faq({ params }: PageProps) {
   setRequestLocale(locale);
 
   const t = await getTranslations({ locale, namespace: "faq" });
+  // `t.raw` reads the message without formatting it. Three answers carry
+  // rich-text tags such as `<spec>` and `<m>`, and `t` needs a chunk function
+  // for every one of them. This page has no chunks to give, because structured
+  // data holds plain text, so `t` failed on those three and returned the key
+  // path. Google then read "faq.items.standards.p3" as the answer. `plainText`
+  // takes the tags off the raw message instead.
   const questions = FAQ_ITEMS.map(({ key, paras }) => ({
-    question: plainText(t(`items.${key}.q`)),
+    question: plainText(t.raw(`items.${key}.q`)),
     answer: Array.from({ length: paras }, (_, i) =>
-      plainText(t(`items.${key}.p${i + 1}`)),
+      plainText(t.raw(`items.${key}.p${i + 1}`)),
     ).join(" "),
   }));
 


### PR DESCRIPTION
## What changed

The FAQ structured data holds the answer text again. Three of the eight answers held a message key.

`src/app/[locale]/faq/page.tsx` reads each message with `t.raw` instead of `t`.

This resolves #124.

## Why

The page builds the FAQPage node with `t`. Three messages carry rich-text tags, such as `<spec>`, `<rashid>` and `<m>`. `t` needs a chunk function for every tag in a message. This page has no chunk function to give, because structured data holds plain text. `t` failed on those three messages and returned the key path. `plainText` then ran on the key path and changed nothing.

Google read `faq.items.standards.p3` as the answer to "Isn't Portolan just STAC and cloud-optimized formats?". The three messages are the same in every locale, so 9 answers carried a key.

`t.raw` reads the message and does not format it, so it needs no chunk function. `plainText` takes the tags off the raw message. That is what the call always intended.

## Verification

Before the change, the FAQPage node on `main` holds a key:

```
$ curl -s http://127.0.0.1:3118/faq | (extract the FAQPage node)
BAD  Isn’t Portolan just STAC and cloud-optimized   -> ...are supposed to provide. faq.items.standards.p3
BAD  Why are agents part of a data publishing sta   -> ...public data infrastructure. faq.items.agents.p2
BAD  What can’t Portolan do yet?                    -> ...such as Zarr and COPC. faq.items.gaps.p2
     8 answers, 3 corrupted
```

After the change, every answer holds prose, in all three locales:

```
$ for P in /faq /es/faq /ar/faq; do curl -s http://127.0.0.1:3117$P | (extract the FAQPage node); done
### /faq ###       8 answers, 0 corrupted
### /es/faq ###    8 answers, 0 corrupted
### /ar/faq ###    8 answers, 0 corrupted
```

The repaired answer ends with the sentence the message holds:

```
...them in ways that reliably deliver the performance and ergonomics they are
supposed to provide. See the Portolan specification and rashid, the Portolan
validator.
```

The server logs no FORMATTING_ERROR:

```
$ grep -c "FORMATTING_ERROR" server.log
0
```

Gates:

```
$ pnpm exec eslint            -> exit 0
$ pnpm exec tsc --noEmit      -> exit 0
$ pnpm exec next build        -> exit 0
$ pnpm test:unit              -> 3 pass, 0 fail
```

The data read is `/faq`, `/es/faq` and `/ar/faq` served from a production build of this repository at commit 51fe78b, and the same three routes served from `main` at 397949a.
