### PR TITLE
fix(home): make every in-page row move the reader on every click

### DIFF
--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -39,7 +39,13 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
       {/* No bottom rule. Every following section carries its own top rule, so
           a bottom rule here would stack with it and draw 2px where the rest of
           the page draws 1px. */}
-      <section id="top" className="relative overflow-hidden">
+      {/* `scroll-mt` keeps the mobile top bar off the headline. That bar is
+          sticky, so it covers the first 59px of the viewport, and a bare jump
+          to `#top` put the h1 under it. The rail's Overview row targets this
+          id. 76px matches the FAQ rows and overshoots the bar, which lands the
+          jump at the top of the document. Desktop has no bar, so the value
+          clamps to 0 there and nothing changes. */}
+      <section id="top" className="relative overflow-hidden scroll-mt-[76px]">
         <GlyphMap className="absolute inset-0 w-full h-full" />
         <div className="absolute inset-0" style={{ background: "var(--hero-scrim)" }} />
         <div className="relative z-10 px-[var(--p-pad-section-x)] pt-[clamp(56px,9vw,120px)] pb-[clamp(40px,6vw,72px)]">

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Link } from "@/i18n/navigation";
 import { GlyphMap } from "./glyph-map";
 import { SiteShell } from "./site-rail";
 import { DemoSection } from "./demo-section";
@@ -76,11 +75,18 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                   pull the box start-ward to make the label line up. The blue
                   block edge is the alignment signal the eye reads, and a
                   negative margin makes it overhang the column. */}
+              {/* Both buttons are plain anchors with a hash target. They point
+                  at sections of this page, so the browser reaches them without
+                  the router. As router `Link`s to `/#how` and `/#coverage`
+                  they asked the router to go to `/`, the page already open.
+                  Each click fetched the page again over RSC, and the router
+                  holds the scroll position on a same-route move, so a button
+                  worked once and then did nothing. */}
               <div className="flex flex-col items-start gap-4 mt-[clamp(2.25rem,4vw,3.25rem)] sm:flex-row sm:items-center sm:gap-6">
                 <Btn asChild variant="primary" size="lg">
-                  <Link href="/#how">
+                  <a href="#how">
                     {t("hero.howItWorks")} <DirArrow />
-                  </Link>
+                  </a>
                 </Btn>
                 {/* The catalogs section on this page, not the registry.
                     Both hero buttons now point into the page, in the order
@@ -89,9 +95,9 @@ export function HomePage({ catalogs = [] }: HomePageProps) {
                     registry, so the reader meets the examples before the
                     full list. */}
                 <Btn asChild variant="ghost" size="lg">
-                  <Link href="/#coverage">
+                  <a href="#coverage">
                     {t("hero.exploreCatalogs")} <DirArrow />
-                  </Link>
+                  </a>
                 </Btn>
               </div>
             </div>

--- a/src/components/site-rail.tsx
+++ b/src/components/site-rail.tsx
@@ -25,6 +25,12 @@ import { SiteFooter } from "./site-footer";
 // targets: the arrow opens the group, the label goes to the homepage. A group
 // with no `href` is a label only, so the whole row toggles.
 //
+// A group that indexes the page the reader is on takes `anchor` as well. Its
+// `href` is the route to that page, which is the page already open, so the
+// click is a same-route navigation and Next.js holds the scroll position. The
+// reader then clicks Overview from inside Ecosystem and nothing moves. The
+// `anchor` gives that row an element on this page to reach instead.
+//
 // The item list is a prop so a standalone page can index its own contents
 // instead of the homepage's.
 
@@ -35,6 +41,11 @@ export type RailItem = {
   label: string;
   /** Set for a route. Omit for an in-page anchor. */
   href?: string;
+  /**
+   * Element id to reach when this group indexes the current page. It wins
+   * over `href` there, because `href` points at the page already open.
+   */
+  anchor?: string;
   /** Set to render the item as a group. */
   children?: RailItem[];
 };
@@ -57,6 +68,9 @@ const HOME_ITEMS: RailItem[] = [
     id: "overview",
     label: "nav.overview",
     href: "/",
+    // The homepage hero. It is the section the other seven anchors sit under,
+    // so Overview reaches the top of the page from anywhere on it.
+    anchor: "top",
     children: OVERVIEW_CHILDREN,
   },
   {
@@ -75,10 +89,13 @@ const HOME_ITEMS: RailItem[] = [
  * becomes a route to the homepage's copy of it, because a bare `#why` on
  * /faq points at an element that does not exist there. A group keeps whatever
  * `href` it has, so Resources stays a label rather than becoming `/#resources`.
+ *
+ * A group loses its `anchor`, because that id names an element on the homepage
+ * and this page does not hold it. The `href` route carries the reader there.
  */
 const toAway = (item: RailItem): RailItem =>
   item.children
-    ? { ...item, children: item.children.map(toAway) }
+    ? { ...item, anchor: undefined, children: item.children.map(toAway) }
     : { ...item, href: item.href ?? `/#${item.id}` };
 
 export const AWAY_ITEMS: RailItem[] = HOME_ITEMS.map(toAway);
@@ -341,7 +358,19 @@ export function SiteShell({
           // span, not a button, because this group does not shut.
           <div className="flex items-center gap-1.5">
             <span className={`${gutter} text-p-ink-3`}>{arrow(true)}</span>
-            {item.href ? (
+            {item.anchor ? (
+              // This group indexes the open page, so the row is an in-page
+              // anchor like its own children. Its route `href` cannot move the
+              // reader here, because it names the page they are already on.
+              <a
+                href={`#${item.anchor}`}
+                onClick={() => closeDrawer()}
+                aria-current={active ? "true" : undefined}
+                className={`flex-1 ${rowBase} ${tone(active)}`}
+              >
+                {t(item.label)}
+              </a>
+            ) : item.href ? (
               <Link
                 href={item.href}
                 onClick={() => closeDrawer()}

--- a/src/components/site-rail.tsx
+++ b/src/components/site-rail.tsx
@@ -22,8 +22,13 @@ import { SiteFooter } from "./site-footer";
 // disclosure arrow over an indented child list.
 //
 // A group may also carry an `href`, and Overview does. That row holds two hit
-// targets: the arrow opens the group, the label goes to the homepage. A group
-// with no `href` is a label only, so the whole row toggles.
+// targets: the arrow opens the group, the label goes to the homepage.
+//
+// A group with neither an `href` nor a page of its own takes `alwaysOpen`, and
+// Resources does. It reads as a heading over its children and it takes no
+// click. As a toggle it looked like the two link rows around it and went
+// nowhere, and on /faq and /talks a click shut the group and hid the link to
+// the page the reader had open.
 //
 // A group that indexes the page the reader is on takes `anchor` as well. Its
 // `href` is the route to that page, which is the page already open, so the
@@ -46,6 +51,11 @@ export type RailItem = {
    * over `href` there, because `href` points at the page already open.
    */
   anchor?: string;
+  /**
+   * Keeps a group open and takes the toggle off its row. Set it on a group
+   * that names its children and has no page of its own.
+   */
+  alwaysOpen?: boolean;
   /** Set to render the item as a group. */
   children?: RailItem[];
 };
@@ -76,6 +86,8 @@ const HOME_ITEMS: RailItem[] = [
   {
     id: "resources",
     label: "nav.resources",
+    // Two children and no page behind the row, so it stays open on every page.
+    alwaysOpen: true,
     children: [
       { id: "talks", label: "nav.talks", href: "/talks" },
       { id: "faq", label: "nav.faq", href: "/faq" },
@@ -179,6 +191,7 @@ export function SiteShell({
   // open, because shutting it would hide the index of the page the reader is
   // on. On the homepage that group is Overview.
   const isLocked = (item: RailItem) =>
+    item.alwaysOpen === true ||
     !!item.children?.some((child) => !child.href);
 
   const isOpen = (id: string) => toggled[id] ?? openByRoute[id] ?? false;


### PR DESCRIPTION
## What changed

Every in-page row on the home page moves the reader, on every click. Three rows worked once and then stopped. One row never worked. A fifth row looked like a link and went nowhere.

- `src/components/home-page.tsx`: the two hero buttons become plain anchors with a hash target.
- `src/components/site-rail.tsx`: a group that indexes the open page takes an `anchor` id and renders an in-page link. Overview points at `top`.
- `src/components/home-page.tsx`: the hero section takes `scroll-mt-[76px]`.
- `src/components/site-rail.tsx`: a group with no page of its own takes `alwaysOpen`. Resources stays open and its row takes no click.

This resolves #125.

## Why

One cause covers the first three rows. Each row was a router `Link` that named the page the reader already had open. The route part of `/#how`, `/#coverage` and `/` is `/`, which is the home page. The router treats that click as a move to the same route. It fetches the RSC payload and holds the scroll position. Next.js documents the rule in `node_modules/next/dist/docs/01-app/03-api-reference/02-components/link.md:232`. The hash reached its target on the first click only, because the URL then carried the hash. Overview carries no hash, so it never moved the reader.

The side rail already links its own sections with a plain `a` and a hash, and those rows always worked. The fix uses that pattern. The browser resolves a hash on its own, so the click needs no router and no request.

The hero takes `scroll-mt-[76px]` because the sticky top bar on small screens covered the headline after the jump. The bar takes 59px. Desktop has no bar, so the value clamps to 0 there.

The Resources row is a separate fault with the same symptom. It carried the styling of Overview and Registry, which are links, so it read as a link. It has no page. A click opened or shut its two children, and on `/faq` and `/talks` a click hid the link to the page the reader had open. The rail already holds Overview open on the home page for this reason. A group that names the reader's page must not hide it.

`alwaysOpen` marks a group that has no page of its own. The toggle stays for any group that gets one later.

## Verification

Before the change, on a production build of `main` served at http://127.0.0.1:3118/, each row clicked three times:

```
$ pnpm exec next build && pnpm exec next start -H 127.0.0.1 -p 3118
$ node click-probe.mjs        # drives http://127.0.0.1:3118/ with Playwright
main, production build. Each link clicked 3 times.

hero button how   target=2705  OK FAIL(0) FAIL(0)
hero button cov   target=3604  OK FAIL(0) FAIL(0)
rail Overview     target=   0  FAIL(4400) FAIL(4400) FAIL(4400)

The Resources row.
/        open=false -> after one click open=true
/faq     open=true  -> after one click open=false
/talks   open=true  -> after one click open=false
```

`target` is the document position of the section. `FAIL(0)` means the page did not move.

After the change, on a production build of this branch served at http://127.0.0.1:3117/:

```
$ pnpm exec next build && pnpm exec next start -H 127.0.0.1 -p 3117
$ node click-probe.mjs        # drives http://127.0.0.1:3117/ with Playwright
Each in-page link, clicked 3 times, on the production build.
target is the document position of the section.
rsc counts server requests made by the clicks only, after prefetch settles.

hero button how   target=2705  OK OK OK  rsc=0
hero button cov   target=3604  OK OK OK  rsc=0
rail Overview     target=   0  OK OK OK  rsc=0

The Resources row on every page.
/           open=true  toggleButton=false
/es         open=true  toggleButton=false
/ar         open=true  toggleButton=false
/faq        open=true  toggleButton=false
/talks      open=true  toggleButton=false
/registry   open=true  toggleButton=false
```

Overview still routes to the home page from a page that it does not index:

```
[2] from /faq:      href=/   -> url=/    scrollY=0  PASS
[2] from /talks:    href=/   -> url=/    scrollY=0  PASS
[2] from /registry: href=/   -> url=/    scrollY=0  PASS
[2] from /es/faq:   href=/es -> url=/es  scrollY=0  PASS
```

The seven child anchors under Overview still reach their sections, and the mobile drawer shuts on the click and clears the sticky bar:

```
[4] #demo PASS  #why PASS  #who PASS  #how PASS  #coverage PASS  #ecosystem PASS  #involved PASS
mobile:  scrollY 5798 -> 0, h1Top=115 barBottom=59  PASS
desktop: scrollY 4447 -> 0, h1Top=120 barBottom=0   PASS
```

The children of Resources still navigate:

```
clicked Talks -> /talks
clicked FAQ   -> /faq
```

Gates:

```
$ pnpm exec eslint            -> exit 0
$ pnpm exec tsc --noEmit      -> exit 0
$ pnpm exec next build        -> exit 0
$ pnpm test:unit              -> 3 pass, 0 fail
$ pnpm test:a11y              -> 43 passed
```

The data read is the pages http://127.0.0.1:3117/, http://127.0.0.1:3117/es, http://127.0.0.1:3117/ar, http://127.0.0.1:3117/faq, http://127.0.0.1:3117/talks and http://127.0.0.1:3117/registry. A production build of this repository at commit d2c762d serves them. The same pages on http://127.0.0.1:3118/ come from `main` at 397949a.
